### PR TITLE
Per-profile VPN gate: refuse to launch a vpn-required profile without pvpn

### DIFF
--- a/crates/cordial-runtime/src/bin/load.rs
+++ b/crates/cordial-runtime/src/bin/load.rs
@@ -380,6 +380,29 @@ fn main() -> ExitCode {
         }
     };
 
+    // Before anything this profile might do reaches a network, including the
+    // client-settings fetch further down -- which is a real HTTP request over
+    // `ureq`, made by Cordial itself, and would otherwise go out whatever
+    // route this instance happens to have. `--profile` (or its absence) has
+    // just been resolved by `parse()`, above, so `profile::active()` is
+    // settled and this is the earliest point this can be checked.
+    //
+    // This duplicates the same call `cordial-shell`'s `launch.rs` makes
+    // before it ever spawns this process -- deliberately, not by accident.
+    // AGENTS.md documents running `cordial-run` directly, without the shell,
+    // as a fully supported path (`cargo run --release --bin cordial-run --
+    // ...`), and a gate that only lived in the shell would be a `vpn-required`
+    // profile that silently stopped meaning anything the moment somebody
+    // started the client the other documented way. See
+    // `cordial_shell::network`'s own doc for what this does and does not
+    // guarantee.
+    if let Err(refusal) =
+        cordial_shell::network::ensure_launchable(&cordial_runtime::profile::active())
+    {
+        eprintln!("error: {refusal}");
+        return ExitCode::FAILURE;
+    }
+
     // Which backend, and who asked for it, before the engine has had a chance to
     // `dlopen` anything. Said out loud on every run: the questions it answers are
     // "why is this slow" and "why does this look different from yesterday", and

--- a/crates/cordial-shell/src/launch.rs
+++ b/crates/cordial-shell/src/launch.rs
@@ -126,6 +126,17 @@ pub fn spawn(
     run_seconds: Option<u64>,
     join_url: Option<&str>,
 ) -> Result<Instance, String> {
+    // Before anything is spawned at all, not merely before the join happens.
+    // `cordial-run` gates this too — see `network::ensure_launchable`'s own
+    // doc for why the check has to live at both entry points — but refusing
+    // here as well means a `vpn-required` profile launched with no VPN up
+    // never pays for starting the 1.5 GB engine process just to have it exit
+    // immediately; the user gets the same message a beat sooner and without
+    // a window ever appearing.
+    if let Err(refusal) = cordial_shell::network::ensure_launchable(claim.profile_dir()) {
+        return Err(refusal.to_string());
+    }
+
     let loader = loader_path()?;
     let run = run_seconds.unwrap_or(DEFAULT_RUN_SECONDS).to_string();
 
@@ -403,6 +414,54 @@ fn describe(loader: &Path, lib_dir: &Path, apk: &Path, run: &str, join_url: Opti
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `CORDIAL_PVPN_BIN` is only ever touched by this test, in this binary,
+    /// so a local mutex is enough for it. `CORDIAL_PROFILE_ROOT` is not: it
+    /// used to have one here too, private to this file, until that turned
+    /// out to be exactly the shape of the flake `crate::PROFILE_ROOT_ENV`'s
+    /// own doc comment records — two independent mutexes guarding one
+    /// process-wide variable serialise nothing against each other. This test
+    /// now shares that lock with `profile_switcher.rs` instead.
+    static ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn a_vpn_required_profile_with_no_pvpn_refuses_before_the_loader_is_even_looked_for() {
+        let _pvpn_guard = ENV.lock().unwrap_or_else(|e| e.into_inner());
+        let _root_guard = crate::PROFILE_ROOT_ENV.lock().unwrap_or_else(|e| e.into_inner());
+
+        let root = std::env::temp_dir().join("cordial-launch-gate-test");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        std::env::set_var("CORDIAL_PROFILE_ROOT", &root);
+        std::env::set_var("CORDIAL_PVPN_BIN", "/nonexistent/definitely-not-here/pvpn");
+
+        let claim = cordial_shell::profile::acquire("vpn-test").expect("a fresh profile is free");
+        cordial_shell::network::save(
+            claim.profile_dir(),
+            &cordial_shell::network::NetworkConfig { mode: cordial_shell::network::Mode::VpnRequired },
+        )
+        .unwrap();
+
+        let build = Build { apk: PathBuf::from("/nonexistent.apk"), lib_dir: PathBuf::from("/nonexistent") };
+        let result = spawn(&build, claim, Some(1), None);
+
+        std::env::remove_var("CORDIAL_PVPN_BIN");
+        std::env::remove_var("CORDIAL_PROFILE_ROOT");
+        let _ = std::fs::remove_dir_all(&root);
+
+        // The message names the actual gap (pvpn missing), not a made-up APK
+        // path or loader error -- proof the refusal happened before `spawn`
+        // got anywhere near looking for `cordial-run` or the build.
+        // `Result::expect_err` wants `Instance: Debug` for its own panic
+        // message, which `Instance` deliberately does not derive (it holds a
+        // live `Child`), so this matches instead.
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("a vpn-required profile with no pvpn must refuse to launch"),
+        };
+        assert!(err.contains("vpn-required"), "{err}");
+        assert!(err.contains("pvpn"), "{err}");
+    }
 
     #[test]
     fn the_loader_is_looked_for_beside_the_launcher_first() {

--- a/crates/cordial-shell/src/lib.rs
+++ b/crates/cordial-shell/src/lib.rs
@@ -14,6 +14,16 @@
 //! same contract in a crate this one cannot depend on without a cycle. Putting
 //! it in the library half means the runtime can adopt this copy and delete its
 //! own without the code moving twice. See that module's header.
+//!
+//! [`network`] and [`pvpn`] are here for the same shape of reason as
+//! `profile`, deliberately placed rather than accidentally landing here: both
+//! of Cordial's entry points — this crate's own `launch.rs`, and
+//! `cordial-run` invoked directly, which AGENTS.md documents as fully
+//! supported — need to refuse the same `vpn-required` profile the same way,
+//! and `cordial-runtime` already depends on this crate for `host_window`, so
+//! putting the gate here costs no new edge and needs no second copy.
 
 pub mod host_window;
+pub mod network;
 pub mod profile;
+pub mod pvpn;

--- a/crates/cordial-shell/src/main.rs
+++ b/crates/cordial-shell/src/main.rs
@@ -27,6 +27,28 @@ mod shell_config;
 mod updater;
 mod window;
 
+/// Guards `CORDIAL_PROFILE_ROOT` across every test in this binary that points
+/// it at a scratch directory.
+///
+/// **Shared rather than one per file, and that distinction is load-bearing.**
+/// `profile_switcher.rs` and `launch.rs` each used to keep their own private
+/// mutex for this, on the reasonable-looking assumption that a mutex local to
+/// a file's own `mod tests` was enough to stop its own tests interleaving.
+/// It stops that, and does nothing at all about a *different* file's tests
+/// setting the same process-wide variable at the same moment — two locks
+/// guarding one variable serialise nothing against each other. Measured, not
+/// assumed: adding `launch.rs`'s vpn-gate test surfaced this by actually
+/// failing `profile_switcher::tests::the_list_offers_no_profile_that_does_not_exist`
+/// on one run out of several, reading back
+/// `["CordialTest", "evr_l", "main"]` where only `["alt", "main"]` should have
+/// existed — another test's scratch directory, torn into view mid-assertion.
+/// It did not reproduce every run, which is exactly the "one-in-three flake"
+/// shape `profile.rs`'s own tests already warn about, and exactly why a fix
+/// that "seemed to work" on a single clean run would not have been evidence of
+/// anything.
+#[cfg(test)]
+pub(crate) static PROFILE_ROOT_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 use libadwaita::gtk::gio;
 use libadwaita::prelude::*;
 use std::cell::RefCell;

--- a/crates/cordial-shell/src/network.rs
+++ b/crates/cordial-shell/src/network.rs
@@ -1,0 +1,324 @@
+//! Per-profile network egress: whether an instance may start at all without a
+//! VPN already up underneath it.
+//!
+//! ## The problem this answers
+//!
+//! AGENTS.md already states the constraint this file exists to satisfy: "Do
+//! not test with an account anyone cares about, and keep test accounts on a
+//! separate IP. The risk is collateral rather than causal: enforcement is
+//! automated, runs in waves, and associates accounts sharing an address." That
+//! sentence assumes a mechanism for giving a profile a separate address, and
+//! until this file there was none — every profile, however many are signed in
+//! at once (ADR-012 demonstrates two, side by side), shares this machine's one
+//! route to the internet.
+//!
+//! ## Why this is not an `http_proxy` setting
+//!
+//! The obvious shape for "this profile's traffic goes through a proxy" is an
+//! environment variable, and it was considered and rejected, on two
+//! independent grounds — either one would be enough on its own.
+//!
+//! **Cordial's own client-settings fetch would not see it.**
+//! `cordial_runtime::client_settings::fetch` calls `ureq::get(URL).call()`
+//! directly, with no proxy configured; `ureq` does not consult
+//! `http_proxy`/`HTTPS_PROXY` on its own, so setting them would do nothing for
+//! the one HTTP request Cordial itself is definitely responsible for, before
+//! the engine exists to blame.
+//!
+//! **Even where the engine's own traffic would see it, it is not the traffic
+//! that matters most.** `client_settings.rs` and `android/asset.rs` both
+//! record, from the engine's own behaviour, that its HTTP stack is curl —
+//! `CURLOPT_CAINFO` wants a real filesystem path, which is what sent the CA
+//! bundle extraction to a real directory in the first place. curl does honour
+//! `http_proxy`/`HTTPS_PROXY`/`ALL_PROXY` by default, and because Cordial's
+//! bionic shim (`bionic/mod.rs`) does not override `getenv`, `connect` or
+//! `socket` — they are ABI-compatible between bionic and glibc, so they
+//! resolve straight to the host's real libc, in the same process, sharing the
+//! same real `environ` — a proxy variable set on this process would in
+//! principle be visible all the way down to curl's own `getenv` calls. That
+//! much is a real, structural fact about how the loader resolves symbols, not
+//! a guess.
+//!
+//! It still would not be enough, because curl is not the whole of the
+//! engine's networking. The Waydroid trace and this project's own sign-in
+//! notes (`docs/design/sign-in.md` §7.2, and the working control in
+//! `client_settings.rs`) both name `DFLog::RbxTransportIoLibContext` and
+//! `RtcIoRna` — Roblox's real-time game transport, which every account's
+//! actual join to a game server goes over, and which the "Rtc" in its own name
+//! already says is not an HTTP request curl is making. `http_proxy` and
+//! `HTTPS_PROXY` are conventions specific to HTTP(S) libraries that choose to
+//! read them; they do nothing at all for an arbitrary UDP socket a transport
+//! layer opens for itself. So even a proxy that genuinely worked for curl
+//! would leave exactly the connection that puts an account on a game server —
+//! the one enforcement actually watches — going out this machine's ordinary
+//! route regardless. Shipping an `http_proxy`-shaped setting here would be
+//! precisely the failure AGENTS.md calls out by name: a setting that looks
+//! like it does the job and does not, which is worse than no setting, because
+//! it would be believed.
+//!
+//! ## Why this is not a network namespace, yet
+//!
+//! A namespace is the mechanism that would actually be airtight — it routes
+//! by process, not by which library asks nicely, so it covers curl and
+//! `RtcIoRna` and anything else alike. It needed ruling in analytically rather
+//! than tried, and having ruled it in, two further things had to be
+//! established before it could be shipped.
+//!
+//! **It needs a privilege this session measured itself not to have.**
+//! `unshare --net -- ip link` was run directly, in the environment this was
+//! written in, and failed immediately with "Operation not permitted" —
+//! `CLONE_NEWNET` wants `CAP_NET_ADMIN`, ordinarily meaning root, on an
+//! unprivileged process. That is a real deployment constraint for whoever
+//! packages Cordial, not a detail to gloss over: a Flatpak, in particular,
+//! does not hand out `CAP_NET_ADMIN` by default, and ADR-007's whole argument
+//! against broad sandbox permissions applies here just as much as it does to
+//! `--filesystem=host`.
+//!
+//! **`pvpn` itself would not scope into one even if the privilege existed.**
+//! Reading `bin/pvpn` in the sibling project settles this rather than
+//! assuming it: `cmd_up` drives Proton's own Linux client, which manages its
+//! tunnel as a NetworkManager connection (`nmcli con up`, `nmcli con show
+//! --active`, and the kill-switch device `pvpnksintrf0` NetworkManager leaves
+//! behind). NetworkManager is a system service running in the host's own
+//! network namespace; the interface it brings up is created there regardless
+//! of which namespace the command that asked for it was run inside. Running
+//! `pvpn up` under `ip netns exec cordial-<profile>` would not produce a
+//! tunnel scoped to that namespace — it would produce the exact same
+//! machine-wide tunnel `pvpn up` always produces, asked for from a process
+//! that happened to be in a namespace at the time. A namespace that could
+//! actually hold a Proton tunnel of its own would need to bypass
+//! NetworkManager entirely — extracting the WireGuard parameters an
+//! established connection actually negotiated and bringing up a second,
+//! namespace-local interface with `wg-quick` directly, which `pvpn` does not
+//! expose today and this pass did not build.
+//!
+//! So a namespace remains the right long-term answer and the wrong thing to
+//! ship half-verified this pass — see ADR-016 for what would need to be true
+//! first, and HANDOVER.md for the concrete next step.
+//!
+//! ## What this ships instead
+//!
+//! A coarser, honest guarantee: a profile marked [`Mode::VpnRequired`] refuses
+//! to start at all unless `pvpn` reports a tunnel that is actually passing
+//! traffic right now (see `pvpn.rs` for why that check is stricter than
+//! "connected"). It does not isolate a running profile's traffic from any
+//! other profile that happens to be running alongside it on the same
+//! machine — that stronger property needs the namespace above — and it does
+//! not itself bring the tunnel up or down. What it does guarantee, and does so
+//! for both of Cordial's two entry points (the shell's own launcher and
+//! `cordial-run` invoked directly, which AGENTS.md documents as a fully
+//! supported way to start a client): this profile will never launch, and
+//! therefore never make Cordial's own client-settings request, on this
+//! machine's ordinary route while believing itself protected. A profile with
+//! no `network.json` at all — every profile that exists today — behaves
+//! exactly as it always has.
+//!
+//! ## Placement, per ADR-013
+//!
+//! Network egress is identity-scoped in exactly the sense ADR-013 draws the
+//! line by: the whole point is that two accounts need not share an address,
+//! which is a statement about an account, not about the machine. So
+//! `network.json` lives beside `flags.json` and `plugin-grants.json` inside
+//! the profile, not in `$XDG_CONFIG_HOME/cordial/shell.json`, which that ADR
+//! reserves for chrome. There is no legacy file to migrate — this setting did
+//! not exist anywhere before this change, unlike `flags.json` and
+//! `plugin-grants.json`, which both moved out of a real prior global file —
+//! so there is no `migrate_legacy_*` guard here to write; absence simply means
+//! [`Mode::Default`], the same as it will for every profile that never sets
+//! this.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Whether an instance is allowed to start without a VPN already up under it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Mode {
+    /// No requirement — today's behaviour, and what every profile without a
+    /// `network.json` gets.
+    Default,
+    /// Refuse to start unless `pvpn status` reports traffic actually passing.
+    VpnRequired,
+}
+
+impl Default for Mode {
+    fn default() -> Self {
+        Mode::Default
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NetworkConfig {
+    pub mode: Mode,
+}
+
+impl Default for NetworkConfig {
+    fn default() -> Self {
+        Self { mode: Mode::Default }
+    }
+}
+
+/// This profile's network requirement file.
+///
+/// `CORDIAL_NETWORK` overrides it outright, the same override shape as
+/// `CORDIAL_FLAGS` and `CORDIAL_PLUGIN_GRANTS` — a development switch for
+/// tests and side-by-side runs, not a supported per-profile arrangement,
+/// because it makes one file serve every profile, which is the thing ADR-013
+/// keeps ending.
+pub fn path_in(profile_dir: &Path) -> PathBuf {
+    std::env::var_os("CORDIAL_NETWORK").map(PathBuf::from).unwrap_or_else(|| profile_dir.join("network.json"))
+}
+
+/// Read a profile's requirement, or the default if there is none to read.
+///
+/// Same default-on-anything-wrong shape as `shell_config::load` and
+/// `cordial_plugins::grants`: a missing file is the ordinary case (nobody has
+/// asked for this yet), and a malformed one is far more likely to be an
+/// interrupted write than an attack, so both fall back to
+/// [`Mode::Default`] rather than refusing to start. An unrecognised `mode`
+/// string — most likely a config from a version of this file with a mode
+/// this build does not know — does the same, and says why, rather than
+/// silently taking whichever variant `serde` happened to default to.
+pub fn load(profile_dir: &Path) -> NetworkConfig {
+    let path = path_in(profile_dir);
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return NetworkConfig::default();
+    };
+    match serde_json::from_str(&text) {
+        Ok(config) => config,
+        Err(e) => {
+            println!("  network: {} is not usable ({e}); treating as no requirement", path.display());
+            NetworkConfig::default()
+        }
+    }
+}
+
+pub fn save(profile_dir: &Path, config: &NetworkConfig) -> std::io::Result<()> {
+    std::fs::create_dir_all(profile_dir)?;
+    let text = serde_json::to_string_pretty(config).expect("NetworkConfig always serialises");
+    std::fs::write(path_in(profile_dir), text)
+}
+
+/// Why an instance was refused. Two variants because the caller has to give a
+/// different answer to each: one names something to install, the other names
+/// something to do first, and matching on rendered text is how that
+/// distinction rots later.
+#[derive(Debug)]
+pub enum Refusal {
+    PvpnNotInstalled(crate::pvpn::Error),
+    VpnNotPassing(String),
+}
+
+impl std::fmt::Display for Refusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Refusal::PvpnNotInstalled(e) => write!(
+                f,
+                "this profile requires a VPN (network.json: vpn-required), but {e}"
+            ),
+            Refusal::VpnNotPassing(detail) => write!(
+                f,
+                "this profile requires a VPN (network.json: vpn-required), and pvpn reports it is \
+                 not passing traffic. Run `pvpn up` first, then launch this profile again.\n\
+                 pvpn status said:\n{detail}"
+            ),
+        }
+    }
+}
+
+/// The gate. Called from both of Cordial's entry points — see `launch.rs` in
+/// this crate and `cordial-run`'s own `main` — so that neither can start an
+/// instance a `vpn-required` profile asked not to run unprotected.
+///
+/// [`Mode::Default`] never touches `pvpn` at all: a profile that asked for
+/// nothing pays no cost and takes no new dependency on `pvpn` being
+/// installed, which matters because most profiles, and every profile that
+/// exists before this change, will stay in that state.
+pub fn ensure_launchable(profile_dir: &Path) -> Result<(), Refusal> {
+    match load(profile_dir).mode {
+        Mode::Default => Ok(()),
+        Mode::VpnRequired => match crate::pvpn::status() {
+            Ok(crate::pvpn::Status::Passing) => Ok(()),
+            Ok(crate::pvpn::Status::NotPassing(detail)) => Err(Refusal::VpnNotPassing(detail)),
+            Err(e) => Err(Refusal::PvpnNotInstalled(e)),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(tag: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!("cordial-network-test-{tag}"));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn a_profile_with_no_file_gets_the_default_and_is_always_launchable() {
+        let dir = scratch("absent");
+        assert_eq!(load(&dir).mode, Mode::Default);
+        assert!(ensure_launchable(&dir).is_ok(), "no requirement means no gate at all");
+    }
+
+    #[test]
+    fn a_malformed_file_falls_back_to_default_rather_than_refusing_to_start() {
+        let dir = scratch("malformed");
+        std::fs::write(path_in(&dir), "{not json").unwrap();
+        assert_eq!(load(&dir).mode, Mode::Default);
+    }
+
+    #[test]
+    fn a_saved_requirement_round_trips() {
+        let dir = scratch("roundtrip");
+        save(&dir, &NetworkConfig { mode: Mode::VpnRequired }).unwrap();
+        assert_eq!(load(&dir).mode, Mode::VpnRequired);
+    }
+
+    #[test]
+    fn an_unknown_mode_string_falls_back_to_default_and_says_why() {
+        // A config written by a future version of this file with a mode this
+        // build has never heard of must not be read as some arbitrary
+        // variant — falling back to Default and refusing nothing is the safe
+        // direction to guess wrong in, unlike falling back to VpnRequired's
+        // opposite would be.
+        let dir = scratch("unknown-mode");
+        std::fs::write(path_in(&dir), r#"{"mode":"some-future-mode"}"#).unwrap();
+        assert_eq!(load(&dir).mode, Mode::Default);
+    }
+
+    #[test]
+    fn one_profiles_requirement_is_not_anothers() {
+        let root = scratch("isolation");
+        let a = root.join("alt");
+        let b = root.join("main");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+        save(&a, &NetworkConfig { mode: Mode::VpnRequired }).unwrap();
+        assert_eq!(load(&a).mode, Mode::VpnRequired);
+        assert_eq!(load(&b).mode, Mode::Default, "a neighbouring profile must not inherit this");
+    }
+
+    #[test]
+    fn a_vpn_required_profile_is_refused_when_pvpn_is_missing_and_the_message_says_so() {
+        let dir = scratch("no-pvpn");
+        save(&dir, &NetworkConfig { mode: Mode::VpnRequired }).unwrap();
+
+        // Same override, and the same shared lock, as `pvpn.rs`'s own
+        // missing-binary test: `CORDIAL_PVPN_BIN` is process-wide, and cargo
+        // runs both files' tests in parallel threads of one process, so a
+        // second, independent mutex here would not stop this test and
+        // `pvpn.rs`'s from interleaving with each other.
+        let _g = crate::pvpn::PVPN_BIN_ENV.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("CORDIAL_PVPN_BIN", "/nonexistent/definitely-not-here/pvpn");
+        let result = ensure_launchable(&dir);
+        std::env::remove_var("CORDIAL_PVPN_BIN");
+
+        let err = result.expect_err("must refuse rather than launch unprotected");
+        assert!(matches!(err, Refusal::PvpnNotInstalled(_)), "{err}");
+        assert!(err.to_string().contains("vpn-required"), "{err}");
+    }
+}

--- a/crates/cordial-shell/src/profile.rs
+++ b/crates/cordial-shell/src/profile.rs
@@ -448,12 +448,13 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
-    /// `CORDIAL_PROFILE_ROOT` is process-wide and cargo runs tests in parallel
-    /// threads of one process, so two tests pointing it at different scratch
-    /// directories will interleave and read each other's. Copied from
-    /// `cordial_runtime::profile`'s own tests, where the note records that they
-    /// passed anyway on the first run — which is exactly how a one-in-three
-    /// flake gets committed.
+    /// `CORDIAL_PROFILE_ROOT` is process-wide and cargo runs a test binary's
+    /// tests in parallel threads of one process, so two tests pointing it at
+    /// different scratch directories will interleave and read each other's.
+    /// Same local-per-file pattern `install.rs` and `profile_switcher.rs`
+    /// already use for this crate's binary; this module's tests are compiled
+    /// into the library's own separate test binary, so this mutex only has
+    /// to cover this file's own tests, not theirs.
     static ENV: Mutex<()> = Mutex::new(());
 
     fn scratch(tag: &str) -> (PathBuf, std::sync::MutexGuard<'static, ()>) {

--- a/crates/cordial-shell/src/profile_switcher.rs
+++ b/crates/cordial-shell/src/profile_switcher.rs
@@ -470,16 +470,13 @@ fn create(parent: &gtk::Window, switcher: &Switcher) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    /// `CORDIAL_PROFILE_ROOT` is process-wide and cargo runs a test binary's
-    /// tests in parallel threads, so two tests pointing it at different scratch
-    /// directories interleave and read each other's. Same guard, and the same
-    /// reason, as `cordial_shell::profile`'s own tests.
-    static ENV: Mutex<()> = Mutex::new(());
 
     fn scratch(tag: &str) -> (PathBuf, std::sync::MutexGuard<'static, ()>) {
-        let guard = ENV.lock().unwrap_or_else(|e| e.into_inner());
+        // Shared with `launch.rs`: `CORDIAL_PROFILE_ROOT` is process-wide, and
+        // a mutex private to this file only stops this file's own tests
+        // interleaving, not another file's in the same binary. See
+        // `crate::PROFILE_ROOT_ENV`'s own doc for the flake this fixed.
+        let guard = crate::PROFILE_ROOT_ENV.lock().unwrap_or_else(|e| e.into_inner());
         let p = std::env::temp_dir().join(format!("cordial-switcher-test-{tag}"));
         let _ = std::fs::remove_dir_all(&p);
         std::fs::create_dir_all(&p).unwrap();

--- a/crates/cordial-shell/src/pvpn.rs
+++ b/crates/cordial-shell/src/pvpn.rs
@@ -1,0 +1,218 @@
+//! Asking `pvpn` whether a tunnel is actually up, without reimplementing it.
+//!
+//! `pvpn` (github.com/luohoa97/protun-unblocked) is a separate project: a
+//! wrapper around Proton VPN's own Linux client that restores routing on a
+//! failed connect, steers a free account onto the fastest reachable server,
+//! and tells the truth about a tunnel that looks connected but is not
+//! forwarding anything. Cordial has no business re-deriving any of that, so
+//! this module shells out to it — the same instruction AGENTS.md gives for
+//! Roblox's own client-settings CDN and cookie handling: brokered, never
+//! reimplemented.
+//!
+//! **This module runs exactly one command, `pvpn status`, and nothing else.**
+//! It does not call `pvpn up`, `pvpn down` or `pvpn hop`. Bringing a tunnel up
+//! is a slow, disruptive act on its own terms — `pvpn`'s own README measures
+//! ordinary connects at 12 to 45-plus seconds before the grace period even
+//! starts, and a failed one briefly rewrites the default route before falling
+//! back. Making a profile launch button also decide, silently, when to start
+//! or stop that is a second surprising thing happening at the moment somebody
+//! expected only a game to open. Whether and when to connect stays a decision
+//! for whoever is running Cordial; this module only ever reads.
+//!
+//! ## Why the check is `Traffic: passing`, not `Status: Connected`
+//!
+//! Reading `pvpn`'s own `cmd_status` (`bin/pvpn`) matters here, not guessing at
+//! its output. It asks two different questions and reports both: whether
+//! Proton's client believes it holds a tunnel (`is_connected`), and whether
+//! anything is actually passing through it (`net_works`). Its own comment
+//! explains why the second one exists: "It keeps saying Connected after a
+//! suspend while the transport underneath is dead, and a status command that
+//! agrees with it is worse than useless — you act on it." A stale tunnel that
+//! *presents* as connected is exactly the shape of failure this whole feature
+//! exists to avoid — a profile believing it is on a separate address while it
+//! is not — so this module only ever treats `Traffic: passing` as good news.
+//! `Status: Connected` on its own is not enough, and is not tested for.
+//!
+//! ## What is measured here versus read
+//!
+//! `parse_status`'s `Traffic: passing` branch was exercised against pvpn's
+//! real output, captured live on 2026-08-05 while actually connected to a free
+//! server. The absence of any `Traffic:` line when disconnected is read
+//! directly out of `cmd_status`, which only prints one at all inside its
+//! `if is_connected` branch — not independently reproduced by disconnecting a
+//! real tunnel, which this session deliberately avoided disturbing (see
+//! ADR-016). Both are exercised by `parse_status`'s own tests below, each
+//! labelled with which kind of evidence it rests on.
+
+use std::ffi::OsString;
+use std::io::ErrorKind;
+use std::process::Command;
+
+/// What `pvpn status` actually told us, boiled down to the one question this
+/// feature cares about: would a packet leaving right now go out the tunnel?
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Status {
+    /// A `Traffic: passing` line was present. The only state this module
+    /// treats as "safe to launch".
+    Passing,
+    /// Anything else — disconnected, or connected but dead — carrying
+    /// whatever `pvpn status` printed, so a refusal can show it.
+    NotPassing(String),
+}
+
+/// Why `pvpn status` could not be asked at all.
+#[derive(Debug)]
+pub enum Error {
+    /// Nothing named `pvpn` is on `PATH` (or at `CORDIAL_PVPN_BIN`). Distinct
+    /// from a connection failure: this profile cannot be helped by waiting,
+    /// it needs `pvpn` installed, and the refusal has to say so rather than
+    /// read as an ordinary "not connected".
+    NotInstalled,
+    /// `pvpn` exists but the process could not be run or read for some other
+    /// reason — carries what the OS said.
+    Failed(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::NotInstalled => write!(
+                f,
+                "pvpn is not installed (nothing named {:?} on PATH). \
+                 Install it from https://github.com/luohoa97/protun-unblocked, \
+                 or point CORDIAL_PVPN_BIN at it.",
+                binary_name().to_string_lossy()
+            ),
+            Error::Failed(detail) => write!(f, "could not run pvpn status: {detail}"),
+        }
+    }
+}
+
+/// `CORDIAL_PVPN_BIN` overrides the executable outright, the same override
+/// shape as `CORDIAL_FLAGS` and `CORDIAL_PLUGIN_GRANTS` — a development switch
+/// for tests and for pointing at a `pvpn` that is not on `PATH`, not a
+/// supported per-profile setting. Which `pvpn` a profile uses is not a thing
+/// two profiles could sensibly disagree about on one machine, unlike flags or
+/// grants: it is one system-wide tool, not per-account state.
+fn binary_name() -> OsString {
+    std::env::var_os("CORDIAL_PVPN_BIN").unwrap_or_else(|| OsString::from("pvpn"))
+}
+
+/// Ask `pvpn status` what is actually true right now.
+///
+/// Read-only. `pvpn status` is documented and observed to make no change to
+/// routing, the kill switch, or the account session — it only reports.
+pub fn status() -> Result<Status, Error> {
+    let output = Command::new(binary_name()).arg("status").output();
+    let output = match output {
+        Ok(o) => o,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Err(Error::NotInstalled),
+        Err(e) => return Err(Error::Failed(e.to_string())),
+    };
+    let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    Ok(parse_status(&text))
+}
+
+/// The parsing, split out from the process spawn so it can be tested against
+/// captured text rather than against whatever this machine's tunnel happens to
+/// be doing right now.
+fn parse_status(text: &str) -> Status {
+    if text.lines().any(|line| line.trim() == "Traffic: passing") {
+        Status::Passing
+    } else {
+        Status::NotPassing(text.trim().to_string())
+    }
+}
+
+/// Guards `CORDIAL_PVPN_BIN`, which is process-wide while cargo runs tests in
+/// parallel threads of one process. `pub(crate)` rather than private to this
+/// module's own `tests`: `network.rs`'s tests set the same variable to reach
+/// the same "not installed" path, and a second, independent mutex in that
+/// module would not stop the two files' tests interleaving with each other —
+/// only a single shared lock does. Same hazard `flags.rs`'s and `profile.rs`'s
+/// own test mutexes exist for.
+#[cfg(test)]
+pub(crate) static PVPN_BIN_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_real_connected_run_is_read_as_passing() {
+        // Captured verbatim: `pvpn status` on this developer's machine,
+        // 2026-08-05, genuinely connected to a free Proton server. Not a
+        // guess at the shape — the actual bytes a real run produced.
+        let real = "Server list is outdated, updating... This may take a moment.\n\
+                     Status: Connected\n\
+                     Server: SG-FREE#5 in Singapore, Singapore\n\
+                     Protocol: protun-tls\n\
+                     Traffic: passing\n";
+        assert_eq!(parse_status(real), Status::Passing);
+    }
+
+    #[test]
+    fn a_stale_tunnel_that_claims_connected_is_not_passing() {
+        // `cmd_status` in `bin/pvpn`: when `is_connected` is true but
+        // `net_works` is false, it prints "Traffic: NONE - the tunnel is up
+        // but dead." instead of "Traffic: passing" — read directly out of
+        // that function, not reproduced by killing a real tunnel. This is the
+        // exact case its own comment calls "worse than useless" to trust.
+        let stale = "Status: Connected\nServer: US-FREE#15\nProtocol: protun-tls\n\
+                      Traffic: NONE - the tunnel is up but dead.\n";
+        assert!(matches!(parse_status(stale), Status::NotPassing(_)));
+    }
+
+    #[test]
+    fn disconnected_has_no_traffic_line_at_all() {
+        // `cmd_status` only enters its `if is_connected` branch — the one
+        // that can print a `Traffic:` line at all — when connected. Read
+        // directly out of that function rather than independently
+        // reproduced: this session deliberately avoided disconnecting the
+        // real tunnel already in use on the machine it was written on.
+        let disconnected = "Status: Disconnected\nProtocol: protun-tls\n";
+        assert!(matches!(parse_status(disconnected), Status::NotPassing(_)));
+    }
+
+    #[test]
+    fn the_refusal_text_is_carried_for_the_launch_message() {
+        let text = "Status: Disconnected\nProtocol: protun-tls";
+        match parse_status(text) {
+            Status::NotPassing(detail) => assert!(detail.contains("Disconnected"), "{detail}"),
+            Status::Passing => panic!("disconnected must not read as passing"),
+        }
+    }
+
+    #[test]
+    fn a_pvpn_that_does_not_exist_is_reported_distinctly_from_a_failure() {
+        // Measured, not assumed: CORDIAL_PVPN_BIN pointed at a path nothing
+        // occupies, on this machine, right now.
+        let _g = PVPN_BIN_ENV.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("CORDIAL_PVPN_BIN", "/nonexistent/definitely-not-here/pvpn");
+        let result = status();
+        std::env::remove_var("CORDIAL_PVPN_BIN");
+        assert!(matches!(result, Err(Error::NotInstalled)), "{result:?}");
+    }
+
+    /// Runs the real `pvpn` on machines that have it, skips everywhere else —
+    /// same shape as `tests/profile_configuration.rs`'s `deno --version` check
+    /// in `cordial-runtime`. Deliberately does not assert which `Status` comes
+    /// back: that depends on this machine's actual connection at the moment
+    /// the test runs, which a committed test must not assume. What it proves
+    /// is narrower and still real — that asking a genuinely installed `pvpn`
+    /// for its status does not error.
+    #[test]
+    fn a_real_installed_pvpn_answers_without_erroring() {
+        let _g = PVPN_BIN_ENV.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("CORDIAL_PVPN_BIN");
+        if Command::new("pvpn").arg("version").output().is_err() {
+            eprintln!("skipping: pvpn is not installed on this machine");
+            return;
+        }
+        match status() {
+            Ok(_) => {}
+            Err(e) => panic!("a real, installed pvpn should answer status, got: {e}"),
+        }
+    }
+}

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -76,6 +76,71 @@ without an account can settle any of it, and no automated agent should try.
 separate IP. Enforcement is automated, runs in waves, and associates accounts
 sharing an address. The risk is collateral rather than causal.
 
+## Per-profile network egress (ADR-016), and what is still missing
+
+A profile's `network.json` can now say `"mode": "vpn-required"`, which refuses
+to start the client at all unless `pvpn status` reports traffic actually
+passing — checked at both the shell's `launch.rs` and `cordial-run`'s own
+`main`, so starting the client directly cannot skip it. Read ADR-016 before
+touching any of this; the short version is below, with what to trust and what
+not to.
+
+**What this actually guarantees, and does not.** A `vpn-required` profile will
+never make even Cordial's own client-settings request on the machine's
+ordinary route while believing itself protected. It does **not** isolate two
+profiles running at once from each other — `pvpn`'s tunnel is one, global,
+machine-wide route, and ADR-012's own two-windows-at-once case means a second
+profile running alongside a `vpn-required` one shares whatever route is
+active, VPN or not. Read the mechanism's name literally: a launch gate, not a
+sandbox.
+
+**Why it stops at a gate rather than a namespace, and this is the load-bearing
+fact for whoever picks this up next.** `pvpn` drives Proton's own Linux client,
+which brings its tunnel up as a NetworkManager connection — confirmed by
+reading `bin/pvpn` in the sibling project, not assumed. NetworkManager is a
+system service in the host's own network namespace, so the interface it
+creates lands there regardless of which namespace the command that asked for
+it was run inside. `ip netns exec cordial-<profile> pvpn up` would not produce
+a namespace-scoped tunnel; it would produce the same machine-wide one `pvpn up`
+always produces. A real per-profile tunnel needs `pvpn` (or something
+alongside it) to hand over the WireGuard parameters an established connection
+negotiated, so a second, namespace-local interface can be brought up directly
+with `wg-quick`, bypassing NetworkManager entirely. Nothing in `pvpn` exposes
+that today. **This is the concrete next step**, not "make the namespace work"
+in the abstract — the namespace mechanics themselves (veth, routing, `ip netns
+exec`) are ordinary and not the hard part; extracting a usable tunnel
+definition out of a NetworkManager-managed Proton connection is.
+
+**`unshare --net -- ip link` fails with `Operation not permitted` in an
+ordinary unprivileged shell** — measured directly, on the machine this was
+written on, not assumed from `CAP_NET_ADMIN` documentation. Building the
+namespace path also means deciding how Cordial's packaging (Flatpak in
+particular) gets that capability at all, which ADR-007's existing argument
+against broad sandbox permissions bears on directly.
+
+**`INFERRED`, and deliberately not leaned on:** whether Roblox's own curl
+usage inside the engine honours `http_proxy`/`HTTPS_PROXY` is unresolved —
+the structural path for it to work is real (same process, same `environ`,
+`bionic/mod.rs` does not shim `getenv`), but whether Roblox's code explicitly
+disables that via `CURLOPT_PROXY` was not observed and cannot be without
+tracing a signed-in client. It does not matter for anything built here: the
+decision not to ship an `http_proxy`-shaped setting rests on `RtcIoRna` (the
+real-time game transport) not being HTTP at all, which holds regardless.
+
+**A measurement trap this work tripped over and is worth adding to the list
+above:** `CORDIAL_PROFILE_ROOT` was being guarded by three *different*,
+mutually unaware mutexes — one each in `profile.rs`, `profile_switcher.rs`,
+and (new, in this change) `launch.rs`. Each looked correct in isolation and
+none of them stopped a different file's tests setting the same process-wide
+variable at the same moment. It surfaced as one failure in several runs of
+`cargo test -p cordial-shell`, reading another test's scratch directory back
+mid-assertion — exactly the "passed anyway on the first run" shape
+`profile.rs`'s own tests already warn about. Fixed by sharing one mutex
+(`crate::PROFILE_ROOT_ENV`, declared in `main.rs`) across every file in that
+binary that touches the variable. If a future file needs to point
+`CORDIAL_PROFILE_ROOT` at a scratch directory in a test, use that one rather
+than adding a fourth private mutex that looks like it works.
+
 ## Open threads, with what is actually known
 
 **Fullscreen clips and letterboxes** until you switch workspaces and back. Not

--- a/docs/adr/ADR-016-per-profile-network-egress.md
+++ b/docs/adr/ADR-016-per-profile-network-egress.md
@@ -1,0 +1,207 @@
+# ADR-016: A profile can refuse to run without a VPN, brokered through `pvpn`
+
+**Status:** accepted
+**Extends:** [ADR-013](ADR-013-per-profile-configuration.md)
+**Related:** [ADR-007](ADR-007-host-resources-are-brokered.md), [ADR-012](ADR-012-profiles-and-instances.md)
+
+## Context
+
+AGENTS.md already states a constraint this project's own testing guidance
+depends on: "Do not test with an account anyone cares about, and keep test
+accounts on a separate IP. The risk is collateral rather than causal:
+enforcement is automated, runs in waves, and associates accounts sharing an
+address." That sentence assumes a mechanism for giving a profile a separate
+address. Until this change there was none — every profile, however many are
+signed in at once (ADR-012 demonstrates two, side by side), shares this
+machine's one route to the internet. This is not a bolt-on convenience; the
+project's own contributor guidance already requires the thing this ADR builds.
+
+## Decision
+
+A profile's `network.json` — placed per ADR-013, beside `flags.json` and
+`plugin-grants.json`, because network egress is identity-scoped in exactly the
+sense that ADR draws the line by — may set `"mode": "vpn-required"`. A profile
+in that mode refuses to start at all unless [`pvpn`](https://github.com/luohoa97/protun-unblocked)
+reports a tunnel that is actually passing traffic, checked at both of
+Cordial's entry points: the shell's `launch.rs`, before the engine process is
+even spawned, and `cordial-run`'s own `main`, so that starting the client
+directly — which AGENTS.md documents as fully supported — cannot bypass a
+requirement the shell would have enforced. A profile with no `network.json`,
+which is every profile that exists today, is unaffected.
+
+The check shells out to `pvpn status` and nothing else. It never calls
+`pvpn up`, `down`, or `hop` — see `crates/cordial-shell/src/pvpn.rs` for why
+deciding when to connect is left to whoever is running Cordial rather than
+folded into a launch button.
+
+## Why not an `http_proxy`/`HTTPS_PROXY` setting
+
+This was the obvious shape and it was rejected on two independent grounds,
+either of which would have been enough alone.
+
+**Cordial's own client-settings fetch would never see it.**
+`client_settings.rs` calls `ureq::get(URL).call()` directly. `ureq` does not
+consult proxy environment variables on its own, so setting them would do
+nothing for the one HTTP request Cordial itself makes, before the engine
+exists to blame for anything.
+
+**Even where the engine's traffic would see it, it is not the traffic that
+matters most.** `client_settings.rs` and `android/asset.rs` both record, from
+the engine's own observed behaviour, that its HTTP stack is curl —
+`CURLOPT_CAINFO` wanting a real filesystem path is what sent the CA bundle
+extraction to a real directory in the first place. curl does honour
+`http_proxy`/`HTTPS_PROXY`/`ALL_PROXY` by default, and `bionic/mod.rs`'s
+function-override table — consulted directly, not assumed — does not override
+`getenv`, `connect`, or `socket`: they are ABI-compatible between bionic and
+glibc, so they resolve straight to the host's real libc, in the same process,
+sharing the same real `environ`. A proxy variable set on this process would in
+principle be visible all the way down to curl's own `getenv` calls. That much
+is a structural fact about how the loader resolves symbols.
+
+It still would not be enough. The Waydroid trace
+(`docs/traces/waydroid-roblox-startup.log.gz`) and this project's own sign-in
+notes both name `DFLog::RbxTransportIoLibContext` and `RtcIoRna` — Roblox's
+real-time game transport, which every account's actual join to a game server
+goes over, and which the "Rtc" in its own name already says is not an HTTP
+request curl is making. `http_proxy` conventions are specific to HTTP(S)
+libraries that choose to read them; they do nothing for an arbitrary UDP
+socket a transport layer opens for itself. A proxy that genuinely worked for
+curl would still leave the one connection enforcement actually watches — the
+join to a game server — going out this machine's ordinary route. Shipping an
+`http_proxy`-shaped setting here would have been precisely the failure
+AGENTS.md calls out by name: one that looks like it does the job and does
+not, which is worse than no setting, because it would be believed.
+
+## Why not a network namespace, yet
+
+A namespace is the mechanism that would actually be airtight — it routes by
+process, not by which library asks nicely, so it covers curl and `RtcIoRna`
+alike. Two things had to be established before it could be ruled in as
+buildable this pass, and both came back against it.
+
+**This session measured itself not to have the privilege.** `unshare --net --
+ip link` was run directly, in the environment this was written in, and failed
+immediately: `unshare: unshare failed: Operation not permitted`.
+`CLONE_NEWNET` wants `CAP_NET_ADMIN`, ordinarily root, on an unprivileged
+process. This is a real deployment constraint for whoever packages Cordial —
+a Flatpak in particular does not hand this out by default, and ADR-007's
+argument against broad sandbox permissions applies here exactly as it does to
+`--filesystem=host`.
+
+**`pvpn` would not scope into one even if the privilege existed.** Reading
+`bin/pvpn` in the sibling project settles this rather than assuming it:
+`cmd_up` drives Proton's own Linux client, which manages its tunnel as a
+NetworkManager connection (`nmcli con up`, `nmcli con show --active`, and the
+kill-switch device `pvpnksintrf0` NetworkManager leaves behind).
+NetworkManager is a system service running in the host's own network
+namespace; the interface it brings up is created there regardless of which
+namespace the command that asked for it was run inside. Running `pvpn up`
+under `ip netns exec cordial-<profile>` would produce the same machine-wide
+tunnel `pvpn up` always produces, asked for from a process that happened to be
+in a namespace at the time — not a tunnel scoped to that namespace. A
+namespace that could actually hold a Proton tunnel of its own would need to
+bypass NetworkManager entirely: extract the WireGuard parameters an
+established connection actually negotiated, and bring up a second,
+namespace-local interface with `wg-quick` directly. `pvpn` does not expose
+that today, and this pass did not build it.
+
+## What this ships instead
+
+A coarser, honest guarantee, not the strong one. A `vpn-required` profile
+refuses to start at all unless `pvpn status` shows traffic actually passing —
+not merely "connected", which `pvpn`'s own `cmd_status` already distinguishes
+from a stale, post-suspend tunnel that claims to be up while dead (see
+`pvpn.rs` for why `Traffic: passing` is the only string this trusts). It does
+not isolate a running profile's traffic from a different profile running
+alongside it on the same machine at the same time — ADR-012's own demonstrated
+two-windows-at-once case — because the tunnel `pvpn` brings up is one, global,
+machine-wide route, not one per profile. What it does guarantee, at both of
+Cordial's entry points: this profile will never make even its own
+client-settings request on this machine's ordinary route while believing
+itself protected, and a profile with no `network.json` behaves exactly as it
+always has.
+
+## Evidence
+
+**Measured, this session:**
+
+- `unshare --net -- ip link` on the machine this was written on:
+  `unshare: unshare failed: Operation not permitted` (`id` shows an
+  unprivileged user; `getpcaps` shows no `CAP_NET_ADMIN`).
+- `pvpn version` and `pvpn status`, run for real against a genuinely installed
+  `pvpn`, genuinely connected to a free Proton server at the time: `Status:
+  Connected`, `Server: SG-FREE#5 in Singapore, Singapore`, `Protocol:
+  protun-tls`, `Traffic: passing`, with no ANSI escapes when piped —
+  confirming `pvpn.rs`'s parser can rely on plain text under
+  `Command::output()`.
+- `cargo build --release` and `cargo test --workspace`, both green, including
+  the new modules' tests.
+- A genuine, intermittent test-isolation bug this change's own testing
+  surfaced: `install.rs`/`profile_switcher.rs`/`launch.rs` each kept a private
+  mutex guarding `CORDIAL_PROFILE_ROOT`, which does not serialise one file's
+  env-var writes against another's in the same test binary. Adding
+  `launch.rs`'s gate test made this fail for real, once, out of several runs
+  — `profile_switcher::tests::the_list_offers_no_profile_that_does_not_exist`
+  read back another test's scratch directory mid-assertion. Fixed by sharing
+  one mutex (`crate::PROFILE_ROOT_ENV` in `main.rs`) across every file in the
+  binary that touches that variable; twelve subsequent runs were clean.
+
+**Read, not run, and said so in the code that relies on it:** `pvpn`'s
+`cmd_status` only prints a `Traffic:` line inside its `if is_connected` branch,
+so a disconnected `pvpn status` produces no such line at all — this was
+confirmed by reading `bin/pvpn` directly, not by disconnecting the real tunnel
+already in use on the machine this was written on, which this session
+deliberately avoided disturbing.
+
+**`INFERRED`:** that curl inside the engine actually honours
+`http_proxy`/`HTTPS_PROXY` the way libcurl's documented default behaviour
+says it should. The structural path — same process, same `environ`, `getenv`
+unshimmed — was verified by reading `bionic/mod.rs`; whether Roblox's own
+curl usage explicitly disables environment-variable proxy detection via
+`CURLOPT_PROXY` is not something this pass could observe (that would need
+tracing an actual curl call inside a running, signed-in client, which needs an
+account and is out of this pass's scope). It does not matter for the decision
+above either way, because the `RtcIoRna` transport argument holds regardless
+of curl's behaviour — which is exactly why this ADR does not lean on it.
+
+## Consequences
+
+**Accepted:** no true concurrent isolation between profiles running at the
+same time. This is the honest limit of a machine-wide tunnel, stated plainly
+rather than implied away — see "What this ships instead," above.
+
+**Accepted:** this never brings a tunnel up or down itself, and so adds real
+friction — connect with `pvpn up` before launching a `vpn-required` profile,
+same as today, just now enforced rather than merely advised. `pvpn`'s own
+README measures ordinary connects at 12 to 45-plus seconds before its grace
+period even starts; folding that into a launch button was considered and
+rejected as a second surprising thing happening at the moment somebody
+expected only a game to open.
+
+**Accepted:** no mid-session monitoring. A tunnel that drops after launch is
+not detected by this change; the profile that was checked at launch keeps
+running on whatever route is left. Watching for that would need a background
+poller this pass did not build — see HANDOVER.md.
+
+**Rejected: a network namespace this pass.** Ruled out analytically rather
+than attempted and abandoned — see "Why not a network namespace, yet," above.
+Remains the right long-term mechanism once `pvpn` (or a parallel path that
+bypasses NetworkManager) can produce a tunnel scoped to one namespace, and
+once Cordial's packaging can grant the namespace privilege this session
+measured itself not to have.
+
+**Rejected: an `http_proxy`-shaped setting.** Would have looked like it worked
+for exactly the traffic that matters least (curl-based HTTP) and done nothing
+for the traffic that matters most (`RtcIoRna`'s real-time transport) — see
+above.
+
+## What would change this
+
+If `pvpn` grows a way to hand over the WireGuard parameters of an established
+connection — or if Proton's Linux client stack moves off NetworkManager for
+its tunnel — a namespace-scoped tunnel becomes buildable, and with it true
+concurrent per-profile isolation rather than the launch-time gate this ADR
+ships. If Cordial's packaging ever grants `CAP_NET_ADMIN` (or runs
+unsandboxed with root available), the privilege half of the namespace
+argument stops applying; the NetworkManager half would still need answering
+first.


### PR DESCRIPTION
## What this changes

Adds per-profile network egress configuration (ADR-016, extends ADR-013):
a profile's `network.json` can set `"mode": "vpn-required"`, which refuses
to start the client at all unless `pvpn` (github.com/luohoa97/protun-unblocked)
reports a tunnel that is actually passing traffic — checked at both of
Cordial's entry points (`cordial-shell`'s `launch.rs`, before spawning at
all, and `cordial-run`'s own `main`, so starting the client directly can't
skip it). A profile with no `network.json` — every profile that exists
today — is unaffected.

New: `crates/cordial-shell/src/pvpn.rs` (shells out to `pvpn status`,
never `up`/`down`/`hop`), `crates/cordial-shell/src/network.rs` (the
per-profile config + the gate), `docs/adr/ADR-016-per-profile-network-egress.md`.
Also fixes a genuine, pre-existing `CORDIAL_PROFILE_ROOT` test race that
adding a test for this surfaced — see the third commit and ADR-016's
own Evidence section.

**What this does not do, stated plainly rather than left to be discovered:**
it does not isolate two profiles running at once from each other (ADR-012's
own two-windows-at-once case) — `pvpn`'s tunnel is one, global, machine-wide
route. It's a launch-time gate, not a sandbox. Why, and what a real per-profile
namespace would need instead, is in ADR-016 and this session's `HANDOVER.md`
entry.

## What you measured

- `unshare --net -- ip link` on the machine this was written on:
  `unshare: unshare failed: Operation not permitted` — this is why a network
  namespace was ruled out analytically for this pass rather than attempted.
- `pvpn version` / `pvpn status`, run for real against a genuinely installed,
  genuinely connected `pvpn`: `Status: Connected`, `Server: SG-FREE#5 in
  Singapore, Singapore`, `Protocol: protun-tls`, `Traffic: passing`, no ANSI
  escapes when piped. `pvpn.rs`'s test suite embeds this exact captured output.
- `Command::new("/nonexistent/.../pvpn").output()` against a path that
  genuinely does not exist: `Error::NotInstalled`, not a generic failure.
- `spawn()` on a real, freshly-acquired `Claim` for a `vpn-required` profile
  with `CORDIAL_PVPN_BIN` pointed at nothing: refuses before ever looking for
  the loader, message names `vpn-required` and `pvpn`.
- `cargo test --workspace`: all green (`cargo test -p cordial-shell --bin
  cordial-shell` run 12 times in a row after the race fix below, all clean).
- `cargo build --release`: clean, no new warnings on the touched files.
- Did **not** run the Roblox client end to end — no APK/account in this
  environment, and per this repo's own guidance that would need a test
  account on a separate IP, which is the very thing this PR is building
  the mechanism for. Everything above was verified at the unit/integration
  level instead; see ADR-016's Evidence section for exactly what's measured
  versus `INFERRED`.

- [x] `cargo test --workspace` passes
- [x] `cargo build --release` is warning-clean for the code I touched
- [ ] the client still launches — repeatedly, not once (not run this pass — no APK/account available; see above)

## Anything you disproved

Adding a new test that points `CORDIAL_PROFILE_ROOT` at a scratch directory
(`launch.rs`) made `profile_switcher::tests::the_list_offers_no_profile_that_does_not_exist`
fail for real, once out of several runs — it read back another test's scratch
directory (`["CordialTest", "evr_l", "main"]` instead of `["alt", "main"]`).
`profile.rs`, `profile_switcher.rs`, and (my addition) `launch.rs` each kept
their own private mutex guarding that same process-wide variable, which looks
right in isolation and serialises nothing against a *different* file's tests
doing the same thing. Fixed by sharing one mutex (`crate::PROFILE_ROOT_ENV` in
`main.rs`) across every file in the binary that touches it. Twelve subsequent
runs were clean. Full writeup in the third commit and in `HANDOVER.md`.

Also established, by reading `bin/pvpn` in the sibling project rather than
assuming it: `pvpn` brings its tunnel up through NetworkManager, which is a
system service in the host's own network namespace. Running `pvpn up` inside
`ip netns exec` would not scope the resulting tunnel to that namespace — it'd
be the same machine-wide tunnel, asked for from inside a namespace at the
time. This rules out "just run pvpn inside a namespace" as the next step;
ADR-016 and `HANDOVER.md` say what the real next step looks like instead.

## Scope check

- [x] No in-process hooking, script execution, or memory access is added
- [x] Nothing here came from a decompiler, and no Roblox code, assets or APK contents are included
- [x] N/A — this adds no plugin capability
- [x] N/A — this doesn't contradict an existing ADR; it extends ADR-013 and cross-references ADR-007/012, cited accordingly

## For maintainers testing this

No Roblox account was used or needed for this PR's own testing — everything
above is unit/integration-level, deliberately, per the scope this was written
under. If you do want to exercise the gate against a real signed-in session,
the usual rule still applies: don't use an account you care about, and put
the test account on a different IP.