### PR TITLE
[tools] Port the Sober issue corpus fetcher to Deno

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ appData/LocalStorage/_memProfStorage*.json
 # Per-environment build outputs (just build distrobox|nix)
 target-distrobox/
 target-nix/
+
+# The Sober issue corpus (tools/sober-corpus/). Other people's GitHub bug
+# reports with no license grant to us — see ADR-017. PII-redacted before it
+# ever lands here, but it stays local regardless.
+tools/sober-corpus/data/

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -141,6 +141,46 @@ binary that touches the variable. If a future file needs to point
 `CORDIAL_PROFILE_ROOT` at a scratch directory in a test, use that one rather
 than adding a fourth private mutex that looks like it works.
 
+## A local Sober issue corpus for triage (ADR-017)
+
+`tools/sober-corpus/` is a Deno tool, not Rust, and it does not touch the
+engine — worth saying plainly because everything else in this file does.
+It pulls vinegarhq/sober's issue tracker (another Roblox-on-Linux project,
+closed source, so its GitHub repo is purely an issue tracker) into a local,
+gitignored, PII-redacted corpus. Sober's tracker is prior art: real users
+hitting real problems on the same engine Cordial loads, with a
+maintainer's actual answer attached. `just sober-corpus-fetch` pulls it;
+`just sober-corpus-derive` filters it down to the cases with a substantive
+maintainer reply. Read `tools/sober-corpus/README.md` for day-to-day use
+and ADR-017 for the reasoning.
+
+**Run and verified, this session, not assumed:** a cold run against the
+live tracker completed in 91.9s, 22 pages, ~44 GraphQL points of a
+5,000/hour budget, and produced 2,195 issues (2,194 at the time the
+original version of this tool was measured elsewhere; the tracker gained
+one issue in the interim, which is itself a small proof the fetch is
+talking to the real, current API). SIGKILLing it mid-run (confirmed dead:
+exit 137) and re-running showed "Resuming an interrupted pass: 3 page(s) /
+300 issue(s) already done this pass" and continued from page 4 rather than
+restarting — the checkpoint scheme works as designed. A warm re-run with
+nothing new to fetch cost one page, 2 points, 4.1s. `grep`ing the full
+corpus for `/home/` turned up zero unredacted username paths (1,786
+occurrences of the redaction marker, one benign non-match that was a
+literal `"me"` string in a user's own malformed `$HOME`, not a real
+username). Cross-checked against `gh api repos/vinegarhq/sober/pulls
+?state=all` — zero of the repo's 20 real pull request numbers appear among
+the 2,195 fetched issue numbers, confirming the GraphQL `issues` connection
+this fetcher uses does not leak pull requests the way REST's `/issues`
+endpoint would.
+
+**Dropped on purpose:** an LLM-scoring harness (`evaluate.ts`, `model.ts`,
+`sampling.ts`, a Cordial-context builder) existed alongside the fetcher in
+the project this was ported from. It called an external LLM API to
+auto-judge diagnoses against the derived set, and the founder explicitly
+cancelled it ("No openrouter"). It is not in this tree and nothing here
+depends on it — what ships is the fetcher and the maintainer-reply quality
+filter that makes the raw corpus worth searching by hand.
+
 ## Open threads, with what is actually known
 
 **Fullscreen clips and letterboxes** until you switch workspaces and back. Not

--- a/docs/adr/ADR-017-sober-issue-corpus.md
+++ b/docs/adr/ADR-017-sober-issue-corpus.md
@@ -1,0 +1,148 @@
+# ADR-017: A local, incremental corpus of Sober's issue tracker
+
+**Status:** accepted
+**Related:** [ADR-008](ADR-008-plugins-are-typescript-on-deno.md), [ADR-015](ADR-015-fetching-the-roblox-build.md)
+
+## Context
+
+[vinegarhq/sober](https://github.com/vinegarhq/sober) is a different project
+running Roblox on Linux. It is closed source, so its GitHub repo is purely
+an issue tracker — but that tracker is prior art in a narrow, valuable
+sense: real users hitting real problems on the same engine Cordial loads,
+with a maintainer's actual answer attached to most of them. When a new
+Cordial issue looks like a graphics glitch, an audio failure, or a login
+hang, the useful question is often "has someone already hit this against
+Sober, and what fixed it" — and until now the only way to answer that was
+to search GitHub by hand, every time.
+
+This needed a fetcher, not a one-off scrape: the corpus is worth keeping
+current as Sober's tracker grows, and re-fetching all 2,000+ issues on every
+run would be wasteful and slow for no reason a checkpoint cannot avoid.
+
+## Decision
+
+`tools/sober-corpus/` is a small set of Deno TypeScript scripts —
+`fetch.ts`, `github-graphql.ts`, `storage.ts`, `types.ts`, `pii.ts`,
+`derive.ts`, `triage.ts` — that pull vinegarhq/sober's issues into a local,
+PII-redacted, gitignored corpus a maintainer can grep. `just
+sober-corpus-fetch` runs it; `just sober-corpus-derive` builds a filtered
+triage set from the raw corpus. See `tools/sober-corpus/README.md` for the
+day-to-day usage and file layout; this ADR is the why, not the how.
+
+**GraphQL, not REST.** REST's `/issues` + `/issues/{n}/comments` shape
+needs a request per issue just for comments; GraphQL nests `comments`
+inside `issues`, so the whole repo pages in a few dozen requests instead of
+thousands. It also matters for correctness, not only cost: REST's
+`/issues` endpoint returns pull requests mixed in with issues, because a PR
+*is* an issue in GitHub's data model. GraphQL's `repository.issues`
+connection does not, so this fetcher structurally cannot leak a PR into the
+corpus — there is no filter to forget, because the query never asks for
+one.
+
+**Incremental by construction, not by a bolted-on diff.** Issues page
+newest-updated-first. Every completed pass records the maximum `updatedAt`
+seen as a high-water mark; the next pass pages backwards from the newest
+issue and stops the instant it reaches one already at or before that mark —
+everything past that point is unchanged. A checkpoint is written after
+*every page*, not just at the end, so a kill mid-run (`SIGKILL` included)
+loses at most the in-flight page; the next run resumes from the saved
+cursor rather than starting over. A fully up-to-date corpus costs one
+GraphQL request per re-run.
+
+**PII redaction before anything touches disk, unconditionally.** These are
+other people's bug reports, routinely pasted straight from a terminal —
+`inxi`/`neofetch`/`journalctl` dumps, stack traces, shell history — which
+means emails, `/home/<user>/` paths, IP addresses, and shell-prompt/`Host:`
+hostnames show up constantly. `pii.ts` strips all of it, plus
+secret-shaped substrings (bearer tokens, provider API keys, JWTs, URL
+userinfo credentials), on write, before a record is ever appended to
+`raw.jsonl`. This matters more here than a typical internal log-redaction
+pass would: Cordial is a public repository, and this corpus is third-party
+users' content with no license grant to Cordial. Redaction is defence in
+depth; the actual thing that keeps this data off GitHub is the next
+paragraph.
+
+**The corpus never leaves the machine.** `tools/sober-corpus/data/` is
+gitignored. 17 MB (at the corpus size measured for this ADR) of other
+people's issue text does not belong in this repo's history, redacted or
+not — it is a local triage aid, not a redistributed artefact, in the same
+sense ADR-015 draws for a fetched Roblox build: fetching something for
+local use is not the same act as shipping it.
+
+**Deno, not Node.** This reaffirms ADR-008 rather than opening a new
+question: Deno is already a Cordial dependency for the plugin runtime, so a
+Deno tool here adds no new toolchain, no `package.json`, no
+`node_modules`. A Node/`tsx` port would have added exactly the dependency
+ADR-008 chose not to carry, for a tool that gains nothing from being Node.
+Deno's built-in `fetch` also means the GraphQL client needs no HTTP
+library at all.
+
+## What this deliberately does not do
+
+An earlier version of this idea paired the fetched corpus with an
+LLM-scoring harness — evaluate a subject model's diagnosis against the
+maintainer's real one, judge it, and triage which findings apply to
+Cordial. That harness (`evaluate.ts`, `model.ts`, `sampling.ts`, and a
+Cordial-specific context builder) is not part of this change. It called an
+external LLM API, which is out of scope here on its own terms, and was
+explicitly not something to build. What ships is the fetcher and the
+maintainer-reply quality filter (`triage.ts`) that makes the raw corpus
+worth searching by hand — nothing that scores or judges anything
+automatically.
+
+## Evidence
+
+**Measured, this session:** a cold run against vinegarhq/sober's live
+tracker: 91.9s, 22 pages, ~44 GraphQL points of a 5,000/hour budget, 2,195
+issues. A warm re-run immediately after, with nothing changed upstream: 1
+page, 0 new/changed, ~2 points, 4.1s — confirming the incremental path is
+near-free, not merely designed to be.
+
+**Measured:** killing the fetcher mid-run with `SIGKILL` (confirmed dead:
+process exit 137) left `checkpoint.json` recording an interrupted pass at
+page 3 / 300 issues, matching `raw.jsonl`'s 300 lines exactly. Re-running
+printed "Resuming an interrupted pass: 3 page(s) / 300 issue(s) already
+done this pass" and continued from page 4 rather than restarting — the
+checkpoint scheme works as designed, not merely as intended.
+
+**Measured:** `grep -o '/home/\[redacted-user\]' raw.jsonl | wc -l` found
+1,786 redactions across the full corpus; a targeted search for `/home/`
+substrings *not* followed by the redaction marker turned up exactly one
+non-match, and it was not a leak — the underlying text was a user's own
+malformed `$HOME` environment variable containing the literal string
+`"me"` (quotes included), not a real username, in an issue reporting a
+Flatpak path-parsing bug.
+
+**Measured:** `gh api "repos/vinegarhq/sober/pulls?state=all&per_page=100"
+--paginate` lists the repository's 20 real pull requests (open and
+closed); cross-referencing those numbers against all 2,195 fetched issue
+numbers found zero overlap, confirming the GraphQL `issues` connection
+this fetcher uses does not leak pull requests into the corpus.
+
+## Consequences
+
+**Accepted:** the corpus is a maintenance surface tied to Sober's tracker
+staying reachable and GitHub's GraphQL schema staying stable. Neither is
+under Cordial's control; if either breaks, the fetcher should fail loudly
+naming what it could not reach, the same standard ADR-015 sets for the
+build fetcher.
+
+**Accepted:** this is a best-effort redaction pass, not a guarantee.
+Freeform pasted logs can leak PII in shapes no regex list fully covers
+(`pii.ts`'s module doc says so directly). It covers the shapes actually
+observed in this tracker's issues; it is not a substitute for keeping the
+output out of the repository, which the `.gitignore` entry does
+unconditionally regardless of redaction quality.
+
+**Rejected, for now:** the LLM-scoring harness described above. Nothing
+here forecloses building it later as its own, separately-decided piece of
+work — this ADR only covers the fetcher and the local triage set it
+produces.
+
+## What would change this
+
+If Sober's tracker or GitHub's GraphQL API changes shape in a way that
+breaks pagination or the point-cost model this fetcher assumes. If the
+corpus needs to be shared beyond one machine, which would need a real
+decision about where it lives and who can read it — not simply removing
+the gitignore entry.

--- a/justfile
+++ b/justfile
@@ -231,3 +231,20 @@ symbols lib_dir:
       | awk '$7=="UND" {print $8}' | sed 's/@.*//' | sort -u > "$new"
     cut -f2 docs/analysis/undefined-symbols.tsv | sort -u > "$old"
     comm -23 "$new" "$old"
+
+# Pull vinegarhq/sober's issue tracker into a local, triage-searchable corpus (ADR-017)
+sober-corpus-fetch:
+    deno run \
+      --allow-net=api.github.com \
+      --allow-env=GITHUB_TOKEN,GH_TOKEN \
+      --allow-run=gh \
+      --allow-read=tools/sober-corpus/data \
+      --allow-write=tools/sober-corpus/data \
+      tools/sober-corpus/fetch.ts
+
+# Derive the triage set (problem + maintainer resolution) from the raw corpus
+sober-corpus-derive:
+    deno run \
+      --allow-read=tools/sober-corpus/data \
+      --allow-write=tools/sober-corpus/data \
+      tools/sober-corpus/derive.ts

--- a/tools/sober-corpus/README.md
+++ b/tools/sober-corpus/README.md
@@ -1,0 +1,86 @@
+# Sober issue corpus
+
+A local, incrementally-updated copy of [vinegarhq/sober](https://github.com/vinegarhq/sober)'s
+issue tracker. Sober is another project running Roblox on Linux — closed
+source, so its GitHub repo is purely an issue tracker — which means it is
+prior art: real users hitting real problems on the same engine Cordial
+loads, with a maintainer's actual answer attached to most of them. The point
+is to give a Cordial maintainer something to search when triaging a new
+issue: has someone already hit this against Sober, and what did Sober's
+maintainer say. See [ADR-017](../../docs/adr/ADR-017-sober-issue-corpus.md)
+for the full reasoning.
+
+This is not code review or reverse engineering of Sober — Sober has no
+source to read, only issue text. It is not customer-facing and never
+committed; see "The data is gitignored" below.
+
+## Running it
+
+```
+just sober-corpus-fetch    # pulls new/changed issues since the last run
+just sober-corpus-derive   # derives the triage set from the raw corpus
+```
+
+`fetch` needs a GitHub token. It reads `GITHUB_TOKEN` or `GH_TOKEN` from the
+environment first; if neither is set, it shells out to `gh auth token`. The
+token is never written to disk or logged.
+
+A cold run pages through every issue in the repo (a few dozen GraphQL
+requests, well under 100 points of a 5,000/hour budget). Every later run is
+incremental: it pages from the newest issue backwards and stops the instant
+it reaches one it has already seen, so a fully up-to-date corpus costs one
+request. A run can be killed at any point — `SIGKILL` included — and the
+next run resumes from the last completed page rather than starting over.
+
+## What it produces
+
+- `data/raw.jsonl` — one JSON object per Sober issue: title, body, state,
+  labels, and the full comment thread, each comment tagged with the
+  commenter's GitHub `authorAssociation` (OWNER/MEMBER/COLLABORATOR reads
+  as "maintainer"; nothing else does). No usernames are stored — only
+  whether a reply was authoritative, never who wrote it.
+- `data/checkpoint.json` — the incremental fetcher's resumption state: the
+  high-water mark from the last completed pass, and the in-progress cursor
+  if a run was interrupted.
+- `data/eval-set.jsonl` — `derive`'s output: one entry per issue that got a
+  *substantive* maintainer reply (see `triage.ts` for what counts as
+  triage noise — "duplicate of #123", "please fill the template" — and gets
+  filtered out), pairing the problem statement with the maintainer's actual
+  resolution. This is the file worth grepping when triaging a new Cordial
+  issue.
+
+## The data is gitignored
+
+`data/` never leaves this machine. These are other people's GitHub bug
+reports with no license grant to Cordial, and Cordial is a public repo.
+Every issue and comment body is PII-redacted on write, before anything
+touches disk (`pii.ts`) — emails, `/home/<user>/` paths, IPv4 addresses, and
+shell-prompt/`Host:`-style hostnames. That redaction is defence in depth,
+not a reason to commit: the repo's `.gitignore` entry for `tools/sober-corpus/data/`
+is what actually keeps this off GitHub.
+
+## Issues only, never pull requests
+
+GitHub's REST `/issues` endpoint returns pull requests mixed in (a PR is an
+issue in GitHub's data model). This fetcher uses the GraphQL API's
+`repository.issues` connection instead, which does not, so nothing here
+needs a PR filter bolted on after the fact.
+
+## Files
+
+| File | Job |
+|---|---|
+| `fetch.ts` | Entry point. Pages the GraphQL API, redacts, writes the checkpoint and raw corpus. |
+| `github-graphql.ts` | The GraphQL client: auth, retries, rate-limit accounting. |
+| `storage.ts` | All disk I/O — atomic writes, corpus/checkpoint load and save. |
+| `types.ts` | Shared types for a raw issue record, the checkpoint, and a derived case. |
+| `pii.ts` | Secret and PII redaction, run on every title/body/comment before it is written. |
+| `triage.ts` | Heuristic filter for "maintainer replied but said nothing" comments. |
+| `derive.ts` | Entry point. Builds `eval-set.jsonl` from `raw.jsonl`; never calls GitHub. |
+
+Deno, not Node: this is a Deno TypeScript tool because Deno is already a
+Cordial dependency for the plugin runtime (ADR-008), so nothing new gets
+installed to run it. `deno fmt`'s default line width was not applied
+uniformly — the existing plugin code under `plugins/` isn't `deno fmt`-clean
+either, and forcing it here would have broken the aligned progress-log
+strings and comments for no benefit.

--- a/tools/sober-corpus/derive.ts
+++ b/tools/sober-corpus/derive.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env -S deno run --allow-read=tools/sober-corpus/data --allow-write=tools/sober-corpus/data
+/**
+ * Derives the triage set from the raw Sober issue corpus (`data/raw.jsonl`).
+ * Separate, re-runnable step from `fetch.ts` on purpose: changing the
+ * derivation or quality-filter logic should never require re-hitting the
+ * GitHub API.
+ *
+ * A derived case pairs a problem statement (title + body + any
+ * non-maintainer comments posted before the first substantive maintainer
+ * reply) with the expected resolution (the substantive maintainer
+ * reply/replies — the strongest ground-truth signal this tracker has,
+ * especially the ones immediately preceding closure). "Maintainer" =
+ * GitHub's own `authorAssociation` of OWNER/MEMBER/COLLABORATOR; see
+ * ADR-017.
+ *
+ * Quality filter (see `triage.ts`): an issue only survives into the derived
+ * set if at least one maintainer reply is substantive — not pure triage
+ * noise ("duplicate of #123", "please fill the template", a bare
+ * "wontfix"). This also structurally excludes NOT_PLANNED/DUPLICATE
+ * closures that never got a real explanation, without needing a separate
+ * stateReason-specific rule: those closures typically ARE the triage
+ * comment this filter targets.
+ *
+ * Usage: just sober-corpus-derive
+ *
+ * @module sober-corpus/derive
+ */
+
+import { loadRawCorpus, saveEvalSet } from "./storage.ts";
+import { isTriageComment } from "./triage.ts";
+import { isMaintainerAssociation } from "./types.ts";
+import type { CommentRecord, EvalCase, IssueRecord } from "./types.ts";
+
+function buildEvalCase(issue: IssueRecord): EvalCase | null {
+  const sortedComments = [...issue.comments].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  const maintainerComments = sortedComments.filter((c) => isMaintainerAssociation(c.authorAssociation));
+  const substantive = maintainerComments.filter((c) => !isTriageComment(c.body));
+
+  if (substantive.length === 0) {
+    return null;
+  }
+
+  const cutoff = substantive[0]!.createdAt;
+  const clarifying: CommentRecord[] = sortedComments.filter(
+    (c) => !isMaintainerAssociation(c.authorAssociation) && c.createdAt < cutoff,
+  );
+
+  const problemParts = [issue.title, issue.body, ...clarifying.map((c) => c.body)].filter(
+    (part) => part && part.trim().length > 0,
+  );
+
+  return {
+    issueNumber: issue.number,
+    title: issue.title,
+    problemStatement: problemParts.join("\n\n---\n\n"),
+    expectedResolution: substantive.map((c) => c.body).join("\n\n---\n\n"),
+    maintainerReplies: maintainerComments.map((c) => ({
+      authorAssociation: c.authorAssociation,
+      createdAt: c.createdAt,
+      body: c.body,
+      precedesClosure: issue.closedAt !== null && c.createdAt <= issue.closedAt,
+    })),
+    state: issue.state,
+    stateReason: issue.stateReason,
+    labels: issue.labels,
+    createdAt: issue.createdAt,
+    updatedAt: issue.updatedAt,
+    closedAt: issue.closedAt,
+  };
+}
+
+function main(): void {
+  const corpus = loadRawCorpus();
+  const issues = [...corpus.values()];
+
+  const evalCases: EvalCase[] = [];
+  let excludedNoMaintainerReply = 0;
+  let excludedOnlyTriageReplies = 0;
+
+  for (const issue of issues) {
+    const hasAnyMaintainerComment = issue.comments.some((c) => isMaintainerAssociation(c.authorAssociation));
+    if (!hasAnyMaintainerComment) {
+      excludedNoMaintainerReply++;
+      continue;
+    }
+    const evalCase = buildEvalCase(issue);
+    if (!evalCase) {
+      excludedOnlyTriageReplies++;
+      continue;
+    }
+    evalCases.push(evalCase);
+  }
+
+  evalCases.sort((a, b) => a.issueNumber - b.issueNumber);
+  saveEvalSet(evalCases);
+
+  console.log(`\nDerived triage set from ${issues.length} issues in the raw corpus`);
+  console.log(`  Excluded — no maintainer reply at all:        ${excludedNoMaintainerReply}`);
+  console.log(`  Excluded — maintainer replied, all triage:    ${excludedOnlyTriageReplies}`);
+  console.log(`  Survived filter (cases written):              ${evalCases.length}`);
+  console.log(`  -> tools/sober-corpus/data/eval-set.jsonl`);
+}
+
+main();

--- a/tools/sober-corpus/fetch.ts
+++ b/tools/sober-corpus/fetch.ts
@@ -1,0 +1,176 @@
+#!/usr/bin/env -S deno run --allow-net=api.github.com --allow-env=GITHUB_TOKEN,GH_TOKEN --allow-run=gh --allow-read=tools/sober-corpus/data --allow-write=tools/sober-corpus/data
+/**
+ * Incremental, resumable fetcher for every issue + comment thread in
+ * `vinegarhq/sober` — another project running Roblox on Linux, whose GitHub
+ * repo is purely an issue tracker (Sober is closed-source; there is no code
+ * here to read, only real users hitting real problems on the same engine
+ * Cordial loads, with maintainer answers attached). Builds a local corpus
+ * (`tools/sober-corpus/data/raw.jsonl`, gitignored) a Cordial maintainer can
+ * search when triaging a new issue: has someone already hit this, and what
+ * did Sober's maintainer say. See ADR-017.
+ *
+ * Incrementality (the core requirement) works like this: GitHub's `issues`
+ * connection is paged newest-updated-first (`orderBy: UPDATED_AT DESC`).
+ * Every completed pass records a `highWaterMark` — the max `updatedAt` seen
+ * across the whole corpus. The NEXT pass pages from the newest issue
+ * backwards and stops the INSTANT it reaches an issue whose `updatedAt` is
+ * already <= that high-water mark — everything past that point is
+ * already-seen and unchanged, so there's no reason to keep paging. A fully
+ * up-to-date corpus therefore costs one GraphQL request per re-run (see
+ * `github-graphql.ts` for the point-cost accounting). A checkpoint
+ * (`data/checkpoint.json`) is written after EVERY page, not just at the end,
+ * so a kill mid-run loses at most the in-flight page — the next run resumes
+ * from the saved `endCursor`, not from scratch.
+ *
+ * Usage:
+ *   just sober-corpus-fetch
+ *   GITHUB_TOKEN=ghp_xxx just sober-corpus-fetch   # instead of `gh auth token`
+ *
+ * @module sober-corpus/fetch
+ */
+
+import { emitEvent, fetchIssuesPage, fetchRemainingComments, type IssueNode } from "./github-graphql.ts";
+import { redactIssuePII } from "./pii.ts";
+import { loadCheckpoint, loadRawCorpus, saveCheckpoint, saveRawCorpus } from "./storage.ts";
+import type { CommentRecord, IssueRecord } from "./types.ts";
+
+const OWNER = "vinegarhq";
+const REPO = "sober";
+const PAGE_SIZE = 100;
+
+async function buildIssueRecord(node: IssueNode): Promise<IssueRecord> {
+  let commentNodes = node.comments.nodes;
+  if (node.comments.pageInfo.hasNextPage && node.comments.pageInfo.endCursor) {
+    emitEvent("sober_corpus.fetch.comment_overflow", {
+      issue: node.number,
+      totalComments: node.comments.totalCount,
+    });
+    const rest = await fetchRemainingComments({
+      owner: OWNER,
+      name: REPO,
+      number: node.number,
+      cursor: node.comments.pageInfo.endCursor,
+    });
+    commentNodes = [...commentNodes, ...rest];
+  }
+
+  const comments: CommentRecord[] = commentNodes.map((c) => ({
+    authorAssociation: c.authorAssociation as CommentRecord["authorAssociation"],
+    createdAt: c.createdAt,
+    body: redactIssuePII(c.body ?? ""),
+  }));
+
+  return {
+    number: node.number,
+    title: redactIssuePII(node.title ?? ""),
+    body: redactIssuePII(node.body ?? ""),
+    state: node.state,
+    stateReason: node.stateReason as IssueRecord["stateReason"],
+    authorAssociation: node.authorAssociation as IssueRecord["authorAssociation"],
+    labels: node.labels.nodes.map((l) => l.name),
+    createdAt: node.createdAt,
+    updatedAt: node.updatedAt,
+    closedAt: node.closedAt,
+    commentCount: comments.length,
+    comments,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+async function main(): Promise<void> {
+  const startedAt = Date.now();
+  const checkpoint = loadCheckpoint();
+  const corpus = loadRawCorpus();
+
+  console.log(`\nSober issue corpus fetch — ${OWNER}/${REPO}`);
+  console.log(`  Corpus on disk: ${corpus.size} issue(s)`);
+  console.log(`  High-water mark: ${checkpoint.highWaterMark ?? "(none — first run)"}`);
+
+  if (!checkpoint.inProgress) {
+    checkpoint.inProgress = {
+      cursor: null,
+      boundary: checkpoint.highWaterMark,
+      candidateHighWaterMark: null,
+      pagesFetchedThisPass: 0,
+      issuesWrittenThisPass: 0,
+      startedAt: new Date().toISOString(),
+    };
+    saveCheckpoint(checkpoint);
+  } else {
+    console.log(
+      `  Resuming an interrupted pass: ${checkpoint.inProgress.pagesFetchedThisPass} page(s) / ` +
+        `${checkpoint.inProgress.issuesWrittenThisPass} issue(s) already done this pass.`,
+    );
+  }
+
+  const pass = checkpoint.inProgress;
+  let stopped = false;
+  let totalCost = 0;
+
+  while (!stopped) {
+    const page = await fetchIssuesPage({ owner: OWNER, name: REPO, pageSize: PAGE_SIZE, cursor: pass.cursor });
+    totalCost += page.rateLimit.cost;
+
+    for (const node of page.nodes) {
+      if (pass.boundary !== null && node.updatedAt <= pass.boundary) {
+        stopped = true;
+        break;
+      }
+      if (pass.candidateHighWaterMark === null) {
+        pass.candidateHighWaterMark = node.updatedAt;
+      }
+      const record = await buildIssueRecord(node);
+      corpus.set(record.number, record);
+      pass.issuesWrittenThisPass++;
+    }
+
+    pass.pagesFetchedThisPass++;
+    if (!stopped) {
+      pass.cursor = page.pageInfo.endCursor;
+    }
+
+    // Durability order matters: persist the issues BEFORE advancing the
+    // checkpoint, so a kill between the two just re-does (harmlessly
+    // overwrites) this page next run rather than silently skipping it.
+    saveRawCorpus(corpus);
+    saveCheckpoint(checkpoint);
+
+    console.log(
+      `  page ${pass.pagesFetchedThisPass}: +${pass.issuesWrittenThisPass} new/changed this pass ` +
+        `(corpus now ${corpus.size}) — cost ${page.rateLimit.cost}, ${page.rateLimit.remaining} pts remaining`,
+    );
+
+    if (!stopped && !page.pageInfo.hasNextPage) {
+      stopped = true;
+    }
+  }
+
+  checkpoint.highWaterMark = pass.candidateHighWaterMark ?? checkpoint.highWaterMark;
+  checkpoint.lastCompletedRunAt = new Date().toISOString();
+  checkpoint.totalIssuesInCorpus = corpus.size;
+  checkpoint.inProgress = null;
+  saveCheckpoint(checkpoint);
+
+  const elapsedS = ((Date.now() - startedAt) / 1000).toFixed(1);
+  console.log(
+    `\nDone in ${elapsedS}s. Corpus: ${corpus.size} issues. ` +
+      `This run: ${pass.issuesWrittenThisPass} new/changed, ${pass.pagesFetchedThisPass} page(s), ` +
+      `~${totalCost} GraphQL point(s).\n` +
+      `Next: just sober-corpus-derive`,
+  );
+  emitEvent("sober_corpus.fetch.completed", {
+    corpusSize: corpus.size,
+    issuesThisPass: pass.issuesWrittenThisPass,
+    pagesThisPass: pass.pagesFetchedThisPass,
+    pointCost: totalCost,
+    elapsedS,
+  });
+}
+
+main().catch((error) => {
+  emitEvent("sober_corpus.fetch.failed", {
+    message: error instanceof Error ? error.message : String(error),
+  });
+  console.error(`\nFetch failed: ${error instanceof Error ? error.message : String(error)}`);
+  Deno.exit(1);
+});

--- a/tools/sober-corpus/github-graphql.ts
+++ b/tools/sober-corpus/github-graphql.ts
@@ -1,0 +1,301 @@
+/**
+ * Minimal GitHub GraphQL client for the Sober issue corpus fetcher.
+ *
+ * Why GraphQL instead of REST: REST's `/issues` + `/issues/{n}/comments`
+ * shape needs one request per issue just for comments — 2,194 issues would
+ * be 2,194+ requests. GraphQL nests `comments` inside `issues` in a single
+ * query, so the whole repo can be paged in a few dozen requests. REST's
+ * `/issues` endpoint also returns pull requests mixed in with issues (a PR
+ * is an issue in GitHub's data model); GraphQL's `repository.issues`
+ * connection does not, which is why this corpus can never leak a PR without
+ * the query itself changing to ask for one.
+ *
+ * Rate limiting: GitHub's GraphQL API is POINT-based, not request-based
+ * (verified live against a token: `rateLimit { cost }` on a 100-issue page
+ * with full comments+labels reported `cost: 2`, matching the documented
+ * formula — sum of `first`/`last` values per connection, divided by 100,
+ * rounded, minimum 1). Every query below requests `rateLimit { remaining
+ * resetAt }` inline so budget is tracked for free, with no extra request.
+ * Budget is 5,000 points/hour for a PAT; a full cold run of this fetcher
+ * against vinegarhq/sober costs well under 100 points.
+ *
+ * @module sober-corpus/github-graphql
+ */
+
+const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
+const MAX_RETRIES = 8;
+const SECONDARY_LIMIT_BASE_BACKOFF_MS = 30_000;
+// Stop proactively once budget gets this low, rather than racing the primary limit to zero.
+const RATE_LIMIT_SAFETY_MARGIN = 50;
+
+export interface RateLimitInfo {
+  limit: number;
+  cost: number;
+  remaining: number;
+  resetAt: string;
+}
+
+export interface CommentNode {
+  authorAssociation: string;
+  createdAt: string;
+  body: string;
+}
+
+export interface IssueNode {
+  number: number;
+  title: string;
+  body: string;
+  state: "OPEN" | "CLOSED";
+  stateReason: string | null;
+  authorAssociation: string;
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string | null;
+  labels: { nodes: Array<{ name: string }> };
+  comments: {
+    totalCount: number;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    nodes: CommentNode[];
+  };
+}
+
+export interface IssuesPage {
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  nodes: IssueNode[];
+  rateLimit: RateLimitInfo;
+}
+
+let cachedToken: string | null = null;
+
+/** Resolves a GitHub token from `GITHUB_TOKEN` or `GH_TOKEN`, falling back to `gh auth token`. Cached after first resolution. */
+export function resolveGitHubToken(): string {
+  if (cachedToken) {
+    return cachedToken;
+  }
+  const envToken = (Deno.env.get("GITHUB_TOKEN") ?? Deno.env.get("GH_TOKEN"))?.trim();
+  if (envToken) {
+    cachedToken = envToken;
+    return cachedToken;
+  }
+  try {
+    const result = new Deno.Command("gh", { args: ["auth", "token"] }).outputSync();
+    if (result.success) {
+      const token = new TextDecoder().decode(result.stdout).trim();
+      if (token) {
+        cachedToken = token;
+        return cachedToken;
+      }
+    }
+  } catch {
+    // fall through to the error below
+  }
+  throw new Error(
+    "No GitHub token available. Set GITHUB_TOKEN or GH_TOKEN, or run `gh auth login` so `gh auth token` succeeds.",
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function sleepUntil(isoTimestamp: string, bufferMs = 2000, onWait?: (waitMs: number) => void): Promise<void> {
+  const waitMs = new Date(isoTimestamp).getTime() - Date.now() + bufferMs;
+  if (waitMs > 0) {
+    onWait?.(waitMs);
+    await sleep(waitMs);
+  }
+}
+
+interface GraphQLResponse<T> {
+  data?: T;
+  errors?: Array<{ type?: string; message: string }>;
+}
+
+/** Emits a structured, single-line JSON event to stderr, so progress on stdout and machine-greppable events stay in separate streams. */
+export function emitEvent(event: string, fields: Record<string, unknown> = {}): void {
+  console.error(JSON.stringify({ event, ...fields }));
+}
+
+/** POSTs a GraphQL query, handling primary rate-limit throttling, secondary (abuse-detection) backoff, and transient 5xx retries. */
+async function graphqlRequest<T>(
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<{ data: T; rateLimit: RateLimitInfo }> {
+  const token = resolveGitHubToken();
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const res = await fetch(GITHUB_GRAPHQL_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "cordial-sober-corpus-fetcher",
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    if (res.status === 403 || res.status === 429) {
+      const retryAfterHeader = res.headers.get("retry-after");
+      const waitMs = retryAfterHeader
+        ? Number(retryAfterHeader) * 1000
+        : SECONDARY_LIMIT_BASE_BACKOFF_MS * 2 ** attempt;
+      emitEvent("sober_corpus.rate_limit.secondary", { attempt, waitMs, status: res.status });
+      if (attempt === MAX_RETRIES) {
+        throw new Error(`GitHub GraphQL secondary rate limit exceeded after ${MAX_RETRIES} retries`);
+      }
+      await sleep(waitMs);
+      continue;
+    }
+
+    if (res.status >= 500) {
+      if (attempt === MAX_RETRIES) {
+        throw new Error(`GitHub GraphQL request failed after ${MAX_RETRIES} retries: HTTP ${res.status}`);
+      }
+      const waitMs = 2000 * 2 ** attempt;
+      emitEvent("sober_corpus.retry.transient_error", { attempt, status: res.status, waitMs });
+      await sleep(waitMs);
+      continue;
+    }
+
+    if (!res.ok) {
+      const bodyText = await res.text().catch(() => "");
+      throw new Error(`GitHub GraphQL request failed: HTTP ${res.status} ${bodyText.slice(0, 500)}`);
+    }
+
+    const body = (await res.json()) as GraphQLResponse<T>;
+
+    if (body.errors && body.errors.length > 0) {
+      const rateLimited = body.errors.some((e) => e.type === "RATE_LIMITED");
+      if (rateLimited && attempt < MAX_RETRIES) {
+        emitEvent("sober_corpus.rate_limit.primary_graphql_error", { attempt });
+        await sleep(60_000);
+        continue;
+      }
+      throw new Error(`GitHub GraphQL errors: ${JSON.stringify(body.errors)}`);
+    }
+
+    if (!body.data) {
+      throw new Error("GitHub GraphQL response had no data and no errors");
+    }
+
+    const rateLimit = (body.data as Record<string, unknown>).rateLimit as RateLimitInfo | undefined;
+    if (rateLimit && rateLimit.remaining < RATE_LIMIT_SAFETY_MARGIN) {
+      emitEvent("sober_corpus.rate_limit.proactive_throttle", {
+        remaining: rateLimit.remaining,
+        resetAt: rateLimit.resetAt,
+      });
+      await sleepUntil(rateLimit.resetAt, 2000, (waitMs) =>
+        emitEvent("sober_corpus.rate_limit.sleeping", { waitMs }));
+    }
+
+    return {
+      data: body.data,
+      rateLimit: rateLimit ?? { limit: 0, cost: 0, remaining: 0, resetAt: new Date().toISOString() },
+    };
+  }
+
+  throw new Error("unreachable: graphqlRequest exhausted retries without returning or throwing");
+}
+
+const ISSUES_PAGE_QUERY = `
+query SoberIssuesPage($owner: String!, $name: String!, $pageSize: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    issues(first: $pageSize, after: $cursor, orderBy: { field: UPDATED_AT, direction: DESC }) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        title
+        body
+        state
+        stateReason
+        authorAssociation
+        createdAt
+        updatedAt
+        closedAt
+        labels(first: 25) { nodes { name } }
+        comments(first: 100) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes { authorAssociation createdAt body }
+        }
+      }
+    }
+  }
+  rateLimit { limit cost remaining resetAt }
+}`;
+
+export async function fetchIssuesPage(params: {
+  owner: string;
+  name: string;
+  pageSize: number;
+  cursor: string | null;
+}): Promise<IssuesPage> {
+  const { data, rateLimit } = await graphqlRequest<{
+    repository: { issues: { pageInfo: IssuesPage["pageInfo"]; nodes: IssueNode[] } };
+  }>(ISSUES_PAGE_QUERY, params);
+
+  return {
+    pageInfo: data.repository.issues.pageInfo,
+    nodes: data.repository.issues.nodes,
+    rateLimit,
+  };
+}
+
+const ISSUE_REMAINING_COMMENTS_QUERY = `
+query SoberIssueRemainingComments($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      comments(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { authorAssociation createdAt body }
+      }
+    }
+  }
+  rateLimit { limit cost remaining resetAt }
+}`;
+
+/**
+ * Fetches comments beyond the first 100 for a single issue. Genuinely rare
+ * but not hypothetical: a full cold run against vinegarhq/sober hit this
+ * path for 3 of 2,195 issues (#297 with 321 comments, #1580 with 166, #1209
+ * with 109), so this is exercised by real data, not defensive code nobody
+ * has seen run.
+ */
+export async function fetchRemainingComments(params: {
+  owner: string;
+  name: string;
+  number: number;
+  cursor: string;
+}): Promise<CommentNode[]> {
+  interface CommentsConnection {
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    nodes: CommentNode[];
+  }
+  interface RemainingCommentsResponse {
+    repository: {
+      issue: {
+        comments: CommentsConnection;
+      };
+    };
+  }
+
+  const collected: CommentNode[] = [];
+  let cursor: string | null = params.cursor;
+  for (;;) {
+    const result: { data: RemainingCommentsResponse; rateLimit: RateLimitInfo } = await graphqlRequest<
+      RemainingCommentsResponse
+    >(ISSUE_REMAINING_COMMENTS_QUERY, {
+      owner: params.owner,
+      name: params.name,
+      number: params.number,
+      cursor,
+    });
+    const comments: CommentsConnection = result.data.repository.issue.comments;
+    collected.push(...comments.nodes);
+    if (!comments.pageInfo.hasNextPage) {
+      break;
+    }
+    cursor = comments.pageInfo.endCursor;
+  }
+  return collected;
+}

--- a/tools/sober-corpus/pii.ts
+++ b/tools/sober-corpus/pii.ts
@@ -1,0 +1,123 @@
+/**
+ * PII redaction for the Sober issue corpus.
+ *
+ * These are real third-party users' bug reports, routinely pasted verbatim
+ * from a terminal: `inxi`/`neofetch`/`journalctl` dumps, stack traces, shell
+ * history. That means email addresses, absolute home paths
+ * (`/home/<username>/...`), IP addresses, and shell-prompt/`Host:`-style
+ * machine hostnames show up constantly. Everything below is redacted on
+ * write, before anything ever lands in raw.jsonl — Cordial is a public repo
+ * and this corpus is other people's bug reports with no license grant to us,
+ * so it stays local (see the repo `.gitignore` entry for this directory's
+ * `data/`) and scrubbed regardless.
+ *
+ * `redactEmbeddedSecrets` below matches secret-shaped substrings — Bearer
+ * tokens, provider-prefixed API keys, JWTs, URL userinfo credentials —
+ * anywhere inside a longer string, rather than only when the whole value IS
+ * one. A whole-value check would miss "auth failed for Bearer sk_live_…"
+ * entirely, and a bug report is exactly the kind of prose that pastes an
+ * error message with a credential in the middle. It is deliberately narrow —
+ * provider-prefixed keys and known token shapes only, not every 24-char
+ * hex-looking run — because a bug report is full of commit hashes, build
+ * numbers and trace ids that are not secrets and are the diagnostic content
+ * this corpus exists to keep.
+ *
+ * The PII patterns (email, home path, IPv4, hostname) are a separate,
+ * broader pass and run after the secret patterns — narrower patterns first,
+ * so a broad PII pattern cannot eat into an already-redacted secret token.
+ *
+ * This is a best-effort, pattern-based scrubber, not a guarantee: freeform
+ * pasted logs can leak PII in shapes no regex list fully covers (e.g. a
+ * hostname embedded in `uname -a` output with no anchoring keyword). It
+ * covers the shapes actually observed in this repo's issues.
+ *
+ * @module sober-corpus/pii
+ */
+
+// `Bearer <token>` / `Basic <token>` anywhere in the string.
+const BEARER_OR_BASIC_PATTERN = /\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi;
+
+// Provider-prefixed API keys: Stripe/OpenAI `sk_`/`pk_`, GitHub
+// `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`, and their kin. Keeps the prefix so the
+// redacted text still says which kind of credential was there.
+const PROVIDER_KEY_PATTERN = /\b(sk|pk|rk|re|ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_-]{12,}/g;
+
+// Slack `xoxb-`/`xoxp-`/...
+const SLACK_TOKEN_PATTERN = /\bxox[bpsoae]-[A-Za-z0-9-]{10,}/g;
+
+// JWTs (three base64url segments) — replaced whole; no part of a JWT is safe
+// to keep, the header and payload are only base64, not encrypted.
+const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g;
+
+// Credentials in a URL userinfo component, e.g. `postgres://user:pw@host`.
+// The host is deliberately kept — that is the diagnostic half.
+const URL_USERINFO_PATTERN = /:\/\/[^\s/@:]+:[^\s/@]+@/g;
+
+/** Redacts secret-shaped substrings embedded anywhere in `text`, without touching the rest of it. */
+function redactEmbeddedSecrets(text: string): string {
+  return text
+    .replace(BEARER_OR_BASIC_PATTERN, (m) => `${m.split(/\s+/)[0]} [redacted]`)
+    .replace(PROVIDER_KEY_PATTERN, (m) => `${m.split("_")[0]}_[redacted]`)
+    .replace(SLACK_TOKEN_PATTERN, (m) => `${m.slice(0, 4)}-[redacted]`)
+    .replace(JWT_PATTERN, () => "[redacted-jwt]")
+    .replace(URL_USERINFO_PATTERN, () => "://[redacted]@");
+}
+
+const EMAIL_PATTERN = /[\w.+-]+@[\w-]+\.[a-zA-Z]{2,}/g;
+
+// `/home/<user>/...` — keep the rest of the path (it's diagnostic: which
+// desktop file, which Flatpak data dir), redact only the username segment.
+const HOME_PATH_PATTERN = /\/home\/[^/\s"'`]+/g;
+
+// IPv4 only (0-255 per octet) to cut down on false positives against version
+// strings, though some ambiguity with e.g. "1.2.3.4"-shaped build numbers is
+// an accepted, documented limitation — see module docstring.
+const IPV4_PATTERN = /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b/g;
+
+// Shell-prompt style `user@host:` (e.g. pasted terminal output like
+// `neil@fedora-box:~/Downloads$`). Redacts both the user and host segments,
+// keeps the path/`$` that follows since that's diagnostic (cwd at time of error).
+const SHELL_PROMPT_PATTERN = /\b[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+(?=:[~/])/g;
+
+// `Host:`/`Hostname:`/`hostname=` lines as commonly pasted from
+// `hostnamectl`/`inxi`/`neofetch` system-info dumps in bug reports.
+const HOSTNAME_LINE_PATTERN = /^(\s*Host(?:name)?\s*[:=]\s*)(\S+)/gim;
+
+function redactEmails(text: string): string {
+  return text.replace(EMAIL_PATTERN, "[redacted-email]");
+}
+
+function redactHomePaths(text: string): string {
+  return text.replace(HOME_PATH_PATTERN, "/home/[redacted-user]");
+}
+
+function redactIPv4(text: string): string {
+  return text.replace(IPV4_PATTERN, "[redacted-ip]");
+}
+
+function redactShellPromptHosts(text: string): string {
+  return text.replace(SHELL_PROMPT_PATTERN, "[redacted-user]@[redacted-host]");
+}
+
+function redactHostnameLines(text: string): string {
+  return text.replace(HOSTNAME_LINE_PATTERN, "$1[redacted-host]");
+}
+
+/**
+ * Redacts secrets and PII from a single piece of free-form issue/comment
+ * text. Order matters: secrets first (narrower, more specific patterns),
+ * then PII (broader patterns that could otherwise eat into an
+ * already-redacted secret token).
+ */
+export function redactIssuePII(text: string): string {
+  if (!text) {
+    return text;
+  }
+  let redacted = redactEmbeddedSecrets(text);
+  redacted = redactEmails(redacted);
+  redacted = redactHomePaths(redacted);
+  redacted = redactShellPromptHosts(redacted);
+  redacted = redactHostnameLines(redacted);
+  redacted = redactIPv4(redacted);
+  return redacted;
+}

--- a/tools/sober-corpus/storage.ts
+++ b/tools/sober-corpus/storage.ts
@@ -1,0 +1,103 @@
+/**
+ * Disk I/O for the Sober issue corpus: the checkpoint file and raw.jsonl.
+ *
+ * Data lands in `tools/sober-corpus/data/` (gitignored — see the repo
+ * `.gitignore` entry and ADR-017). It must never be committed: these are
+ * third-party GitHub users' bug reports with no license grant to Cordial,
+ * kept strictly as a local triage aid, never a redistributed artefact.
+ *
+ * Both `raw.jsonl` and `checkpoint.json` are written via write-to-temp-then-
+ * rename so a kill mid-write can never leave a half-written file behind —
+ * rename is atomic on the same filesystem, so a reader always sees either
+ * the old complete file or the new complete file, never a partial one.
+ *
+ * `raw.jsonl` is always rewritten in full from the in-memory `Map<number,
+ * IssueRecord>` (sorted by issue number) rather than appended to. This is
+ * what makes "idempotent, no duplicate records" trivial: the Map is the
+ * single source of truth, keyed by issue number, so re-processing the same
+ * issue on a resumed or re-run pass just overwrites its entry — there is no
+ * append-then-dedupe step to get wrong.
+ *
+ * @module sober-corpus/storage
+ */
+
+import type { Checkpoint, EvalCase, IssueRecord } from "./types.ts";
+import { emptyCheckpoint } from "./types.ts";
+
+export const DATA_DIR = `${import.meta.dirname}/data`;
+export const RAW_JSONL_PATH = `${DATA_DIR}/raw.jsonl`;
+export const CHECKPOINT_PATH = `${DATA_DIR}/checkpoint.json`;
+export const EVAL_SET_PATH = `${DATA_DIR}/eval-set.jsonl`;
+
+function ensureDataDir(): void {
+  Deno.mkdirSync(DATA_DIR, { recursive: true });
+}
+
+function existsSync(path: string): boolean {
+  try {
+    Deno.statSync(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/** Writes `contents` to `filePath` atomically (temp file + rename on the same directory/filesystem). */
+function writeFileAtomic(filePath: string, contents: string): void {
+  ensureDataDir();
+  const tmpPath = `${filePath}.tmp-${Deno.pid}-${Date.now()}`;
+  Deno.writeTextFileSync(tmpPath, contents);
+  Deno.renameSync(tmpPath, filePath);
+}
+
+export function loadCheckpoint(): Checkpoint {
+  ensureDataDir();
+  if (!existsSync(CHECKPOINT_PATH)) {
+    return emptyCheckpoint();
+  }
+  const raw = Deno.readTextFileSync(CHECKPOINT_PATH);
+  return JSON.parse(raw) as Checkpoint;
+}
+
+export function saveCheckpoint(checkpoint: Checkpoint): void {
+  writeFileAtomic(CHECKPOINT_PATH, `${JSON.stringify(checkpoint, null, 2)}\n`);
+}
+
+/**
+ * Loads the current corpus into a Map keyed by issue number. Handles a
+ * corpus file written by an OLDER version of this script that used
+ * append-only writes (defensive: last-line-wins on duplicate keys), even
+ * though the current writer never produces duplicates itself.
+ */
+export function loadRawCorpus(): Map<number, IssueRecord> {
+  const map = new Map<number, IssueRecord>();
+  if (!existsSync(RAW_JSONL_PATH)) {
+    return map;
+  }
+  const contents = Deno.readTextFileSync(RAW_JSONL_PATH);
+  for (const line of contents.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const record = JSON.parse(trimmed) as IssueRecord;
+    map.set(record.number, record);
+  }
+  return map;
+}
+
+export function saveRawCorpus(corpus: Map<number, IssueRecord>): void {
+  const sorted = [...corpus.values()].sort((a, b) => a.number - b.number);
+  const contents = sorted.map((record) => JSON.stringify(record)).join("\n");
+  writeFileAtomic(RAW_JSONL_PATH, contents.length > 0 ? `${contents}\n` : "");
+}
+
+/** Writes the derived triage set (derive.ts's output). Not incrementally checkpointed — a re-run regenerates it whole from raw.jsonl, which is cheap and always safe. */
+export function saveEvalSet(cases: EvalCase[]): void {
+  ensureDataDir();
+  const contents = cases.map((c) => JSON.stringify(c)).join("\n");
+  Deno.writeTextFileSync(EVAL_SET_PATH, contents.length > 0 ? `${contents}\n` : "");
+}

--- a/tools/sober-corpus/triage.ts
+++ b/tools/sober-corpus/triage.ts
@@ -1,0 +1,80 @@
+/**
+ * Heuristic classifier for "triage noise": a maintainer comment that closes
+ * or dismisses an issue without actually diagnosing anything — "duplicate
+ * of #123", "please fill the template", a bare "wontfix". These pass the
+ * "has a maintainer reply" bar but carry no ground-truth diagnostic content,
+ * so including them in the derived set would surface triage boilerplate to
+ * a Cordial maintainer instead of a real diagnosis. Quality of the set
+ * matters more than volume here (see ADR-017).
+ *
+ * This is a pattern-based heuristic, not a classifier trained on labelled
+ * data — it will have both false positives (a genuinely short but correct
+ * fix, e.g. "Set `WINEDEBUG=-all`, that's the crash") and false negatives (a
+ * long-winded comment that still says nothing). It is deliberately
+ * conservative: patterns target specific, common triage phrasings rather
+ * than a generic word-count cutoff, to avoid discarding real short answers.
+ *
+ * @module sober-corpus/triage
+ */
+
+const BARE_CLOSING_PHRASES = new Set([
+  "closing",
+  "closed",
+  "duplicate",
+  "dup",
+  "wontfix",
+  "won't fix",
+  "not planned",
+  "stale",
+  "no longer relevant",
+  "invalid",
+  "works for me",
+  "cannot reproduce",
+  "can't reproduce",
+  "fixed",
+  "done",
+  "resolved",
+  "thanks",
+  "thank you",
+]);
+
+function wordCount(body: string): number {
+  return body.trim().split(/\s+/).filter(Boolean).length;
+}
+
+/** True if `body` is triage boilerplate rather than a substantive diagnosis/fix. */
+export function isTriageComment(rawBody: string | undefined | null): boolean {
+  const body = (rawBody ?? "").trim();
+  if (body.length < 8) {
+    return true;
+  }
+
+  const normalized = body.toLowerCase().replace(/[.!\s]+$/, "");
+  if (BARE_CLOSING_PHRASES.has(normalized)) {
+    return true;
+  }
+
+  const words = wordCount(body);
+
+  // "duplicate of #123" / "dup of #456" — a link, not a diagnosis.
+  const looksLikeDuplicateReference = /\bdup(?:e|licate)?\b/i.test(body) && /#\d+/.test(body);
+  if (looksLikeDuplicateReference && words < 20) {
+    return true;
+  }
+
+  // "please fill out the issue template" — a process nudge, not an answer.
+  const looksLikeTemplateRequest = /please\s+(fill|use|complete|follow)\b/i.test(body) && /\btemplate\b/i.test(body);
+  if (looksLikeTemplateRequest && words < 40) {
+    return true;
+  }
+
+  // "please share your logs" — still gathering information, not resolving.
+  const looksLikeInfoRequest =
+    /please\s+(provide|share|post|attach|upload|paste)\b/i.test(body) &&
+    /\b(log|logs|screenshot|screenshots|steps|info|information|trace|output)\b/i.test(body);
+  if (looksLikeInfoRequest && words < 30) {
+    return true;
+  }
+
+  return false;
+}

--- a/tools/sober-corpus/types.ts
+++ b/tools/sober-corpus/types.ts
@@ -1,0 +1,125 @@
+/**
+ * Shared types for the Sober issue corpus fetcher and eval-set derivation.
+ *
+ * "Maintainer" throughout this module means GitHub's own `authorAssociation`
+ * classification of OWNER, MEMBER, or COLLABORATOR — never a hardcoded
+ * username. See ADR-017 for why this corpus exists and what it is for.
+ *
+ * @module sober-corpus/types
+ */
+
+/** GitHub's `CommentAuthorAssociation` enum, verified live against the GraphQL schema. */
+export type AuthorAssociation =
+  | "OWNER"
+  | "MEMBER"
+  | "COLLABORATOR"
+  | "CONTRIBUTOR"
+  | "FIRST_TIME_CONTRIBUTOR"
+  | "FIRST_TIMER"
+  | "MANNEQUIN"
+  | "NONE";
+
+/** GitHub's `IssueStateReason` enum, verified live against the GraphQL schema. */
+export type IssueStateReason = "COMPLETED" | "NOT_PLANNED" | "DUPLICATE" | "REOPENED" | null;
+
+export const MAINTAINER_ASSOCIATIONS: ReadonlySet<AuthorAssociation> = new Set([
+  "OWNER",
+  "MEMBER",
+  "COLLABORATOR",
+]);
+
+export function isMaintainerAssociation(association: AuthorAssociation): boolean {
+  return MAINTAINER_ASSOCIATIONS.has(association);
+}
+
+/**
+ * A single comment on an issue. Deliberately has no `login`/`author` field —
+ * a maintainer triaging a Cordial issue needs to know WHETHER a reply is
+ * authoritative (authorAssociation), never WHO wrote it.
+ */
+export interface CommentRecord {
+  authorAssociation: AuthorAssociation;
+  createdAt: string;
+  /** PII-redacted at write time — see pii.ts. */
+  body: string;
+}
+
+/** Faithful, redacted capture of one GitHub issue. One JSON object per line in raw.jsonl. */
+export interface IssueRecord {
+  number: number;
+  title: string;
+  /** PII-redacted at write time. */
+  body: string;
+  state: "OPEN" | "CLOSED";
+  stateReason: IssueStateReason;
+  authorAssociation: AuthorAssociation;
+  labels: string[];
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string | null;
+  commentCount: number;
+  comments: CommentRecord[];
+  /** When this snapshot of the issue was captured (not a GitHub field). */
+  fetchedAt: string;
+}
+
+/** Persisted resumption state. Written after every page, not just at the end. */
+export interface Checkpoint {
+  schemaVersion: 1;
+  /** Max `updatedAt` across the whole corpus as of the last COMPLETED pass. null before the first ever run. */
+  highWaterMark: string | null;
+  lastCompletedRunAt: string | null;
+  totalIssuesInCorpus: number;
+  /** Non-null only while a pass is actively running or was interrupted mid-pass. */
+  inProgress: InProgressPass | null;
+}
+
+export interface InProgressPass {
+  /** endCursor to resume `after:` from. null means "start of this pass". */
+  cursor: string | null;
+  /** highWaterMark frozen at the moment this pass started; stop once we see updatedAt <= boundary. */
+  boundary: string | null;
+  /** updatedAt of the first (i.e. most-recently-updated) issue seen this pass; becomes the new highWaterMark on completion. */
+  candidateHighWaterMark: string | null;
+  pagesFetchedThisPass: number;
+  issuesWrittenThisPass: number;
+  startedAt: string;
+}
+
+export function emptyCheckpoint(): Checkpoint {
+  return {
+    schemaVersion: 1,
+    highWaterMark: null,
+    lastCompletedRunAt: null,
+    totalIssuesInCorpus: 0,
+    inProgress: null,
+  };
+}
+
+/**
+ * One derived triage case: a Sober problem report paired with the
+ * maintainer's actual resolution — the thing a Cordial maintainer greps for
+ * when a new issue looks familiar. "Maintainer" is GitHub's own
+ * `authorAssociation` of OWNER/MEMBER/COLLABORATOR; see triage.ts for the
+ * substantive-reply filter that decides what survives into this set.
+ */
+export interface EvalCase {
+  issueNumber: number;
+  title: string;
+  /** Title + body + clarifying non-maintainer comments prior to the first substantive maintainer reply. */
+  problemStatement: string;
+  /** Concatenated substantive (non-triage) maintainer reply bodies, in order. */
+  expectedResolution: string;
+  maintainerReplies: Array<{
+    authorAssociation: AuthorAssociation;
+    createdAt: string;
+    body: string;
+    precedesClosure: boolean;
+  }>;
+  state: "OPEN" | "CLOSED";
+  stateReason: IssueStateReason;
+  labels: string[];
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string | null;
+}


### PR DESCRIPTION
## What this changes

Adds `tools/sober-corpus/` — a Deno TypeScript tool that pulls
[vinegarhq/sober](https://github.com/vinegarhq/sober)'s GitHub issue tracker
into a local, PII-redacted, gitignored corpus. Sober is another
Roblox-on-Linux project, closed source, so its tracker is prior art: real
users hitting real problems on the same engine Cordial loads, with a
maintainer's answer attached to most of them. `just sober-corpus-fetch`
pulls it incrementally; `just sober-corpus-derive` filters it down to
issues with a substantive maintainer reply, for a maintainer to grep when
triaging a new Cordial issue.

Ported mechanically from a working TypeScript/Node implementation built
elsewhere for the same purpose against the same repo: `node:fs` ->
`Deno.*Sync`, `process.env` -> `Deno.env.get`, `execFileSync('gh', ...)` ->
`Deno.Command('gh', ...).outputSync()`. Deno rather than Node because Deno
is already a Cordial dependency for the plugin runtime (ADR-008) — this
adds no new toolchain, no `package.json`, no `node_modules`.

**Kept:** `fetch.ts`, `github-graphql.ts`, `storage.ts`, `types.ts`,
`pii.ts`, `derive.ts`, `triage.ts`.

**Dropped:** an LLM-scoring harness (`evaluate.ts`, `model.ts`,
`sampling.ts`, a context builder) that called an external LLM API to
auto-judge diagnoses. Out of scope on its own terms and explicitly not
something to build here. Also dropped the `DiagnosticScore`/`TriageClass`/
`EvalResult` types and the `loadEvalResults`/`saveEvalResults` storage
helpers that existed only to serve that harness and have zero callers
among the kept files.

See [ADR-017](docs/adr/ADR-017-sober-issue-corpus.md) for the full
reasoning (GraphQL vs REST, the incremental checkpoint design, why
redaction runs unconditionally even though gitignore is what actually
keeps this off GitHub) and `tools/sober-corpus/README.md` for day-to-day
use. `docs/HANDOVER.md` has a short section pointing at both.

## What you measured

- **Cold run** against the live tracker: 91.9s, 22 pages, ~44 GraphQL
  points of a 5,000/hour budget, 2,195 issues written to `raw.jsonl` (14
  MB; 17 MB including the derived set and checkpoint).
- **Warm re-run** immediately after: 1 page, 0 new/changed, ~2 points,
  4.1s.
- **Resumption:** killed the fetcher mid-run with `SIGKILL` (confirmed
  dead: process exit 137). `checkpoint.json` recorded an interrupted pass
  at page 3 / 300 issues, matching `raw.jsonl`'s 300 lines exactly.
  Re-running printed `Resuming an interrupted pass: 3 page(s) / 300
  issue(s) already done this pass` and continued from page 4 rather than
  restarting.
- **PII redaction:** grepping the full corpus for `/home/` substrings not
  followed by the redaction marker found exactly one non-match, and it was
  not a leak — a user's own malformed `$HOME` env var containing the
  literal string `"me"` (quotes included), not a real username. 1,786
  genuine redactions fired elsewhere in the corpus. No raw emails found.
- **No pull requests leaked:** cross-referenced vinegarhq/sober's 20 real
  pull requests (`gh api repos/vinegarhq/sober/pulls?state=all`) against
  all 2,195 fetched issue numbers — zero overlap, confirming the GraphQL
  `issues` connection this fetcher uses (rather than REST's `/issues`,
  which mixes PRs in) does not leak them.
- **A real edge case this run found, not merely retained defensively:**
  `fetchRemainingComments` (the >100-comments-per-issue path) fired for 3
  of 2,195 issues (#297 with 321 comments, #1580 with 166, #1209 with
  109). Corrected a stale comment in `github-graphql.ts` that claimed this
  path had never been observed to fire — it now has, by issue number.

- [x] `cargo test --workspace` passes (unaffected — this change touches no
      Rust; ran it anyway per AGENTS.md, all green: 70+ tests across every
      crate, 0 failed)
- [x] `cargo build --release` is warning-clean for the code I touched
      (again, no Rust touched; ran a full release build to confirm the
      tree is untouched, it succeeded cleanly)
- [ ] the client still launches — not applicable; this PR adds no code
      that runs in, or is loaded by, the client. Verified instead by
      actually running the tool end to end (above), per this project's own
      "verify by running" standard applied to what this change actually
      touches.

## Anything you disproved

`github-graphql.ts` carried a comment claiming no issue in this tracker had
been observed with more than 100 comments (the trigger for a second,
paginated fetch). That was true of whatever sample it was written against,
and false of the live tracker — three issues in this cold run needed it.
Corrected in the same commit rather than left to mislead the next reader.

## Scope check

- [x] No in-process hooking, script execution, or memory access is added
- [x] Nothing here came from a decompiler, and no Roblox code, assets or
      APK contents are included — this only touches Sober's issue tracker
      text, not Roblox or Sober's own code
- [x] Not applicable — adds no plugin capability
- [x] Not applicable — doesn't contradict an existing ADR; adds a new one
      (ADR-017)

## For maintainers testing this

No client involved, no account needed to run `just sober-corpus-fetch` or
`just sober-corpus-derive` — just a GitHub token (`GITHUB_TOKEN`/`GH_TOKEN`,
or `gh auth login`). `tools/sober-corpus/data/` is gitignored, so a local
run leaves nothing to clean up in git.

---

Not merging this — leaving it open per the task this was built from.
