### PR TITLE
refactor(profile): use shell claim from runtime

### DIFF
--- a/crates/cordial-runtime/src/profile.rs
+++ b/crates/cordial-runtime/src/profile.rs
@@ -1,65 +1,26 @@
-//! Profiles: one account's storage, and the lock that keeps one window on it.
+//! Profiles: which one this instance runs, resolved through the shell's claim.
 //!
-//! See [ADR-012](../../../docs/adr/ADR-012-profiles-and-instances.md) for the
-//! vocabulary, which matters here. An *instance* is a running Cordial process —
-//! a window, which is what Roblox means by the word. A *profile* is the
-//! directory this module resolves: one account's Roblox storage, plugin set and
-//! flag overrides. An instance runs a profile.
+//! ADR-012's profile lock lived here and in `cordial_shell::profile` at once,
+//! because `cordial-runtime` depends on `cordial-shell` for `host_window` and
+//! the reverse edge would cycle. The shell copy is the one that has to take the
+//! claim (the launcher), and it grew holder identification the runtime never
+//! had. Keeping two implementations of a lock that guards a stored login is
+//! exactly the pair that drifts — so this module is now the runtime-only
+//! process state (`set_active` / `active`) on top of the shell's lock, not a
+//! second flock.
 //!
-//! Nothing structurally prevents two Cordial processes opening the same profile.
-//! Unlike Fishstrap on Windows there is no singleton mutex to defeat, because
-//! each Cordial process is genuinely independent — which is what makes
-//! multi-instance nearly free here. That same freedom is the hazard: two
-//! instances on one profile are two processes writing one `appData` and one
-//! cookie store, and Roblox's storage is not built for it. The failure does not
-//! look like "you did something unsupported"; it looks like Cordial corrupting a
-//! login.
-//!
-//! A profile now holds configuration as well as storage — the user's
-//! `flags.json`, `plugin-grants.json`, and `plugins/<id>/settings.json` for
-//! each plugin that keeps anything. It briefly held the session too, once the
-//! engine turned out never to write its cookies anywhere: `cookies` and
-//! `identity`, both `0600`. Those moved to the desktop secret service
-//! (`secrets.rs`, and ADR-012's second correction) and land here only on a
-//! machine that has none. The directory still *keys* them — an item is found by
-//! this path — so what a profile is has not changed, only where the bytes are.
-//! See
-//! [ADR-013](../../../docs/adr/ADR-013-per-profile-configuration.md), which
-//! extends ADR-012 and records why grants in particular had to stop being
-//! global: a plugin approved in a throwaway profile was silently approved in
-//! the profile someone plays on. Only the profile *directory* is decided here;
-//! what goes in it is resolved by `flags.rs` and by `cordial_plugins`, both of
-//! which take the directory rather than looking it up for themselves.
+//! See [ADR-012](../../../docs/adr/ADR-012-profiles-and-instances.md).
 
-use std::ffi::c_int;
-use std::fs::File;
-use std::os::unix::fs::PermissionsExt;
-use std::os::unix::io::AsRawFd;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::OnceLock;
 
-extern "C" {
-    fn flock(fd: c_int, operation: c_int) -> c_int;
-}
+pub use cordial_shell::profile::{
+    acquire, dir, is_valid_name, list, migrate_legacy_layout, root, Claim, Error, Holder,
+};
 
-/// `LOCK_EX | LOCK_NB` from `sys/file.h`. Non-blocking on purpose: a second
-/// launch should say so immediately rather than hang waiting for the first to
-/// exit, which reads as the client failing to start.
-const LOCK_EX_NB: c_int = 2 | 4;
-
-/// Where profiles live. `$XDG_DATA_HOME/cordial/profiles`, falling back the way
-/// the rest of the tree does.
-pub fn root() -> PathBuf {
-    std::env::var_os("CORDIAL_PROFILE_ROOT")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            std::env::var_os("XDG_DATA_HOME")
-                .map(PathBuf::from)
-                .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")))
-                .unwrap_or_else(std::env::temp_dir)
-                .join("cordial/profiles")
-        })
-}
+/// Historical name for [`Claim`]. The runtime never called `acquire` outside
+/// tests; keep the alias so older call sites and docs stay readable.
+pub type Lock = Claim;
 
 /// The profile an instance runs when it was told nothing else.
 ///
@@ -81,10 +42,6 @@ static ACTIVE: OnceLock<PathBuf> = OnceLock::new();
 /// underneath it.** Flag overrides, plugin grants and each plugin's settings
 /// are all resolved from this one directory, so a second argument naming any
 /// of them would be a second source of truth for something already decided.
-/// Settings in particular must not be passed in on the command line: they are
-/// read from the profile while the client runs, and the `DFFlag`/`DFInt`/
-/// `DFString` families exist precisely so that a value can change mid-session
-/// (ADR-005). An argument is fixed at exec and could never express that.
 ///
 /// Refuses a second, different answer rather than taking it. Changing profile
 /// under a running engine would mean two `appData` directories in one session,
@@ -94,11 +51,7 @@ pub fn set_active(dir: PathBuf) -> Result<(), String> {
     // Create and tighten here as well as in `acquire`, because they are not the
     // same door. The launcher calls `acquire`, which does both; a hand-started
     // `cordial-run --profile <name>` calls only this, and so ran against a
-    // directory `create_dir_all` had left at the umask's `0755`. That was
-    // survivable while the profile only held Roblox's own storage. It is not
-    // now that Cordial writes a session token into it — see `cookies.rs` and
-    // ADR-012 — so the mode is applied wherever a profile is chosen, not only
-    // where it is locked.
+    // directory `create_dir_all` had left at the umask's `0755`.
     let _ = std::fs::create_dir_all(&dir);
     restrict_to_owner(&dir);
     match ACTIVE.set(dir.clone()) {
@@ -120,109 +73,13 @@ pub fn active() -> PathBuf {
     ACTIVE.get().cloned().unwrap_or_else(|| root().join(DEFAULT_NAME))
 }
 
-/// A profile name that cannot escape the profile root.
-///
-/// Names reach this from a command line and, later, from the launcher's own UI,
-/// so `../` and absolute paths are refused rather than sanitised — quietly
-/// rewriting a name would mean the profile a user selected is not the one they
-/// get. Same reasoning as the zip-slip defence in `android::asset`.
-pub fn is_valid_name(name: &str) -> bool {
-    !name.is_empty()
-        && name.len() <= 64
-        && name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-}
-
-pub fn dir(name: &str) -> Result<PathBuf, String> {
-    if !is_valid_name(name) {
-        return Err(format!(
-            "{name:?} is not a usable profile name; use letters, digits, - and _"
-        ));
-    }
-    Ok(root().join(name))
-}
-
-/// An instance's claim on a profile, released when this is dropped.
-///
-/// The file is deliberately held open: `flock` is tied to the open description,
-/// so closing the handle releases the lock. Storing it here means the lock lives
-/// exactly as long as the value, and the process exiting — cleanly or not —
-/// releases it, which a lock file containing a PID would not.
-#[derive(Debug)]
-pub struct Lock {
-    _file: File,
-    path: PathBuf,
-}
-
-impl Lock {
-    pub fn profile_dir(&self) -> &Path {
-        &self.path
-    }
-}
-
-/// Take this instance's claim on `name`, creating the profile if it is new.
-///
-/// Fails immediately if another instance holds it. **Advisory, and honestly so:**
-/// `flock` does not stop a process that never asks. It stops Cordial doing this
-/// by accident, which is the actual failure mode — someone launching twice, not
-/// someone defeating a lock.
-pub fn acquire(name: &str) -> Result<Lock, String> {
-    let path = dir(name)?;
-    std::fs::create_dir_all(&path).map_err(|e| format!("{}: {e}", path.display()))?;
-    restrict_to_owner(&path);
-
-    let lock_path = path.join(".lock");
-    let file = File::create(&lock_path).map_err(|e| format!("{}: {e}", lock_path.display()))?;
-
-    // SAFETY: `file` is open for the duration of the call and outlives it.
-    if unsafe { flock(file.as_raw_fd(), LOCK_EX_NB) } != 0 {
-        return Err(format!(
-            "profile {name:?} is already open in another Cordial window; \
-             use a different profile, or close that one first"
-        ));
-    }
-    Ok(Lock { _file: file, path })
-}
-
 /// Make a profile directory readable only by its owner.
 ///
-/// The profile holds a live session, so `create_dir_all` applying the process
-/// umask — `0755` on a normal desktop — would let any other account on the
-/// machine take it.
-///
-/// **The paragraph that used to stand here was wrong, and the correction is the
-/// point of this comment.** It said Cordial "never reads or handles" a session
-/// token, that the engine reads its cookie from a file at startup, and rejected
-/// a keyring partly on that basis. The engine does no such thing: a complete
-/// `CORDIAL_TRACE_PATHS=1` inventory of every non-system file it opens contains
-/// no cookie jar, and `grep -rl ROBLOSECURITY` over a real profile tree finds
-/// nothing. The engine keeps its cookies in memory and expects the Java side of
-/// the app to persist them, which on Android it does and under Cordial nothing
-/// did — that is the whole of why signing in and restarting presented as being
-/// logged out. Cordial now reads the jar out of the engine and writes it here,
-/// so it *is* the custodian of a session token. See `cookies.rs` and ADR-012,
-/// which records the reversal rather than quietly dropping the old reasoning.
-///
-/// **And the paragraph that replaced it was wrong in its turn.** It said the
-/// keyring was "still rejected... the token has to be handed to the engine in
-/// plaintext on every launch, so a keyring would encrypt it only while nothing
-/// is using it, in exchange for an unlock prompt on every start". A token in
-/// the clear inside a running process is not a token in the clear on disk for
-/// ever, and there is no prompt: `org.freedesktop.secrets` answers on this
-/// platform and its default collection is unlocked by the session login. The
-/// session and the identity now live in the Secret Service — see
-/// [`crate::secrets`], and ADR-012's second correction, which names the
-/// objection as mine.
-///
-/// This mode still matters, and for more than the fallback. The profile holds
-/// `flags.json`, `plugin-grants.json` and Roblox's own `appData`, and the
-/// `0600` store is still what a machine with no secret service falls back to.
-///
-/// Best-effort: a filesystem without Unix permissions is not a reason to refuse
-/// to launch, and the failure is reported by the launch continuing rather than
-/// by a panic.
-fn restrict_to_owner(path: &Path) {
+/// Same contract as the private helper in `cordial_shell::profile`: best-effort
+/// `0700`, kept here because `set_active` is the door that does not go through
+/// `acquire`.
+fn restrict_to_owner(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
     if let Ok(meta) = std::fs::metadata(path) {
         let mut perms = meta.permissions();
         if perms.mode() & 0o077 != 0 {
@@ -232,68 +89,6 @@ fn restrict_to_owner(path: &Path) {
     }
 }
 
-/// Move a pre-ADR-012 layout into place, once.
-///
-/// Storage used to live at `cordial/instances/default/run`, which named a window
-/// and contained a login. Renaming without moving would present as being logged
-/// out for no reason, which is the class of failure this project keeps a list
-/// of, so the directory is moved rather than abandoned.
-///
-/// Runs only when the old path exists and the new one does not, so it cannot
-/// clobber a profile someone has already used.
-pub fn migrate_legacy_layout() -> Option<PathBuf> {
-    let legacy = std::env::var_os("XDG_DATA_HOME")
-        .map(PathBuf::from)
-        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")))
-        .unwrap_or_else(std::env::temp_dir)
-        .join("cordial/instances/default");
-    let target = root().join("default");
-    if !legacy.is_dir() || target.exists() {
-        return None;
-    }
-    if let Some(parent) = target.parent() {
-        std::fs::create_dir_all(parent).ok()?;
-    }
-    match std::fs::rename(&legacy, &target) {
-        Ok(()) => {
-            // The legacy directory was created with the old umask, so tighten it
-            // on the way in rather than inheriting a world-readable cookie.
-            restrict_to_owner(&target);
-            println!(
-                "  profiles: moved {} to {} (ADR-012)",
-                legacy.display(),
-                target.display()
-            );
-            Some(target)
-        }
-        // A cross-device rename is the one plausible failure. Leaving the old
-        // directory in place and saying so beats a half-copied login.
-        Err(e) => {
-            println!(
-                "  profiles: could not move {} to {} ({e}); the old location is untouched",
-                legacy.display(),
-                target.display()
-            );
-            None
-        }
-    }
-}
-
-/// Profiles that exist, for the launcher's switcher.
-pub fn list() -> Vec<String> {
-    let Ok(entries) = std::fs::read_dir(root()) else {
-        return Vec::new();
-    };
-    let mut names: Vec<String> = entries
-        .flatten()
-        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
-        .filter_map(|e| e.file_name().into_string().ok())
-        .filter(|n| is_valid_name(n))
-        .collect();
-    names.sort();
-    names
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -301,14 +96,12 @@ mod tests {
 
     /// `CORDIAL_PROFILE_ROOT` is process-wide and cargo runs tests in parallel
     /// threads of one process, so two tests pointing it at different scratch
-    /// directories will interleave and read each other's. They passed anyway on
-    /// the first run, which is exactly how a one-in-three flake gets committed —
-    /// this project already has one of those in its history. Serialised instead.
+    /// directories will interleave and read each other's.
     static ENV: Mutex<()> = Mutex::new(());
 
     fn scratch(tag: &str) -> (PathBuf, std::sync::MutexGuard<'static, ()>) {
         let guard = ENV.lock().unwrap_or_else(|e| e.into_inner());
-        let p = std::env::temp_dir().join(format!("cordial-profile-test-{tag}"));
+        let p = std::env::temp_dir().join(format!("cordial-runtime-profile-test-{tag}"));
         let _ = std::fs::remove_dir_all(&p);
         std::fs::create_dir_all(&p).unwrap();
         std::env::set_var("CORDIAL_PROFILE_ROOT", &p);
@@ -316,65 +109,10 @@ mod tests {
     }
 
     #[test]
-    fn a_name_cannot_escape_the_profile_root() {
-        // A profile name reaches this from a command line and from the
-        // launcher's UI. Sanitising rather than refusing would mean the profile
-        // someone selected is not the one they get.
-        assert!(!is_valid_name("../../etc"));
-        assert!(!is_valid_name("/absolute"));
-        assert!(!is_valid_name("has/slash"));
-        assert!(!is_valid_name(""));
-        assert!(is_valid_name("default"));
-        assert!(is_valid_name("alt_account-2"));
-    }
-
-    #[test]
-    fn a_second_instance_cannot_take_a_held_profile() {
-        // The whole point of ADR-012's lock: two instances on one profile are
-        // two processes writing one cookie store, and the corruption that
-        // follows presents as a Cordial bug rather than as unsupported use.
-        let (_root, _g) = scratch("held");
-        let first = acquire("default").expect("first instance takes the profile");
-        let second = acquire("default");
-        assert!(second.is_err(), "a second instance must be refused");
-        assert!(second.unwrap_err().contains("already open"));
-        drop(first);
-    }
-
-    #[test]
-    fn releasing_a_profile_lets_the_next_instance_have_it() {
-        // flock is tied to the open file description, so dropping the Lock must
-        // actually release it — including when the process died rather than
-        // exited, which a PID file would not handle.
-        let (_root, _g) = scratch("released");
-        let first = acquire("default").unwrap();
-        drop(first);
-        assert!(acquire("default").is_ok(), "the profile must be reusable");
-    }
-
-    #[test]
-    fn a_profile_is_not_readable_by_other_users() {
-        // create_dir_all applies the umask, which on a normal desktop gives
-        // 0755 — another account on the machine could read everything in here.
-        // This comment used to end "this is the whole of Cordial's credential
-        // protection", which was true and is the reason it no longer is: the
-        // session moved to the secret service. The mode still matters for the
-        // flag overrides, the plugin grants, Roblox's own appData, and for the
-        // fallback store on a machine with no service.
-        let (_root, _g) = scratch("perms");
-        let lock = acquire("default").unwrap();
-        let mode = std::fs::metadata(lock.profile_dir())
-            .unwrap()
-            .permissions()
-            .mode();
-        assert_eq!(mode & 0o077, 0, "profile must not be group- or world-accessible");
-    }
-
-    #[test]
     fn the_active_profile_is_decided_once_and_defaults_to_the_migrated_one() {
         // One test rather than three, because `ACTIVE` is a `OnceLock` and the
-        // fallback can only be observed before anything has set it. Written as
-        // a sequence for that reason, not for brevity.
+        // fallback can only be observed before anything has set it. Lock
+        // behaviour lives in `cordial_shell::profile` tests now.
         let (_root, _g) = scratch("active");
         assert_eq!(
             active(),
@@ -387,25 +125,10 @@ mod tests {
         set_active(chosen.clone()).unwrap();
         assert_eq!(active(), chosen);
 
-        // Saying yes to the same answer twice is not a conflict; the launcher
-        // and the client both resolving the same argument is ordinary.
         assert!(set_active(chosen.clone()).is_ok());
 
-        // A different answer is. Two profiles in one session means two appData
-        // directories, which is the corruption the lock exists to prevent
-        // arriving by another door.
         let refused = set_active(dir("main").unwrap());
         assert!(refused.is_err(), "a second, different profile must be refused");
         assert_eq!(active(), chosen, "and the first answer must still stand");
-    }
-
-    #[test]
-    fn different_profiles_do_not_contend() {
-        // Multi-instance is the point: two windows on two profiles is the
-        // supported shape and must not block.
-        let (_root, _g) = scratch("distinct");
-        let a = acquire("main").unwrap();
-        let b = acquire("alt").unwrap();
-        assert_ne!(a.profile_dir(), b.profile_dir());
     }
 }

--- a/crates/cordial-shell/src/profile.rs
+++ b/crates/cordial-shell/src/profile.rs
@@ -9,21 +9,11 @@
 //! presents as a Cordial bug rather than as unsupported use, which is why the
 //! lock is not left to convention.
 //!
-//! **This is the same contract `cordial_runtime::profile` implements, written
-//! twice.** That is not a design; it is where the dependency graph left it.
-//! `cordial-runtime` depends on this crate for `host_window`, so this crate
-//! cannot depend on `cordial-runtime` without a cycle, and the launcher is the
-//! process that has to take the claim — `cordial-run` never calls its own
-//! `profile` module at all today, so the runtime's copy is currently unreached
-//! code. Two implementations of a lock that guards a credential is exactly the
-//! kind of pair that drifts, so this one lives in the *library* half of
-//! `cordial-shell` rather than in the binary: the runtime can adopt it and
-//! delete its copy without anything moving a second time. Wording of the
-//! refusal message is deliberately identical between the two so that a user
-//! searching for it finds one answer.
-//!
-//! The precedent for reimplementing rather than linking is `flags_file.rs`,
-//! which does the same for the flags path and says why in its own header.
+//! **This is the single implementation of ADR-012's profile claim.** It lives
+//! in the library half of `cordial-shell` so the launcher can take the claim
+//! and `cordial-runtime` can re-export it without a dependency cycle
+//! (`cordial-runtime` already depends on this crate for `host_window`). The
+//! runtime keeps only process-local state (`set_active` / `active`) on top.
 
 use std::ffi::c_int;
 use std::fs::File;


### PR DESCRIPTION
## Summary
- Make `cordial-runtime::profile` re-export the shell's ADR-012 claim instead of shipping a second flock.
- Keep runtime-only `set_active` / `active` / `DEFAULT_NAME` (process state the shell does not own).
- Update the shell module header to match the single-implementation layout.

## Notes
- Finding: the runtime copy never called `acquire` outside its own tests (`cordial-run` only uses `set_active` / `active` / `dir` / `migrate_legacy_layout`). The shell copy already covers hand-off and holder identification.
- Local `cargo test` needs GTK/`pkg-config` which this environment lacks; please run `cargo test --workspace` on CI/your machine.

Closes #6