### PR TITLE
fix(jni): expose device profile and hook WebRTC BuildInfo getters

### DIFF
--- a/native/init_params.cpp
+++ b/native/init_params.cpp
@@ -237,6 +237,58 @@ static const char* device_identity_label() {
     return "roblox-app";
 }
 
+/// Device-identity strings for surfaces that need brand/model/build fields
+/// without inventing a second `device_identity()` switch.
+///
+/// Exposed (non-static) the same way `S_pub` is: other translation units link
+/// against one accessor rather than copy the profile table. `BuildInfo` in
+/// `unanswered_classes.cpp` is the first consumer — hooking those getters
+/// against a local table would make `CORDIAL_DEVICE_PROFILE` change InitParams
+/// and the User-Agent while leaving WebRTC's BuildInfo on a stale answer.
+///
+/// Values stay inside Cordial's own honest vocabulary (manufacturer/device
+/// name already report `"Cordial"`). Only the fields that legitimately differ
+/// by profile — model/device/product form factor, and the Android release
+/// string — change with the switch. `sdk_version` stays `"33"` for every
+/// profile: `DeviceParams.osVersion` is load-bearing for Vulkan and is not
+/// varied by profile either.
+struct DeviceProfile {
+    const char* brand;
+    const char* manufacturer;
+    const char* model;
+    const char* device;
+    const char* product;
+    const char* build_id;
+    const char* build_type;
+    const char* build_release;
+    const char* sdk_version;
+};
+
+const DeviceProfile& device_profile() {
+    static const DeviceProfile v = []() -> DeviceProfile {
+        switch (device_identity()) {
+            case DeviceIdentity::PcWindows11:
+                // model matches mocktail's `class=pc model="Windows 11 PC"`
+                // line; device/product keep the PC form factor distinct from
+                // the tablet identity so a BuildInfo read can see the switch.
+                return DeviceProfile{"Cordial", "Cordial", "Windows 11 PC",
+                                     "cordial_pc", "cordial_pc", "cordial", "user",
+                                     "11", "33"};
+            case DeviceIdentity::AndroidTablet:
+                return DeviceProfile{"Cordial", "Cordial", "Cordial", "cordial",
+                                     "cordial", "cordial", "user", "13", "33"};
+            case DeviceIdentity::RobloxApp:
+                // Bare app token: no form-factor claim beyond Cordial's own
+                // name, matching the User-Agent arm that drops the device block.
+                return DeviceProfile{"Cordial", "Cordial", "Cordial", "cordial",
+                                     "cordial", "cordial", "user", "13", "33"};
+        }
+        return DeviceProfile{"Cordial", "Cordial", "Cordial", "cordial", "cordial",
+                             "cordial", "user", "13", "33"};
+    }();
+    return v;
+}
+
 /// The `User-Agent` the engine puts on every HTTP request it makes.
 ///
 /// **This was `"Roblox/Android"`, and the comment above it was wrong in the most

--- a/native/unanswered_classes.cpp
+++ b/native/unanswered_classes.cpp
@@ -52,6 +52,22 @@ using jnivm::ENV;
 using jnivm::Object;
 using jnivm::String;
 
+/// Device profile from `init_params.cpp` — one source of truth for brand /
+/// model / build fields. Declared rather than shared through a header because
+/// the framework layer's cross-file surface is declarations like `S_pub`.
+struct DeviceProfile {
+    const char* brand;
+    const char* manufacturer;
+    const char* model;
+    const char* device;
+    const char* product;
+    const char* build_id;
+    const char* build_type;
+    const char* build_release;
+    const char* sdk_version;
+};
+const DeviceProfile& device_profile();
+
 namespace {
 
 std::shared_ptr<String> S(const char* v) {
@@ -204,29 +220,49 @@ public:
 
 /// `org.webrtc.voiceengine.BuildInfo`
 ///
-/// Registered, with **no getter hooked**, and that is a considered choice
-/// rather than an unfinished one.
+/// Nine static device-identity getters. Names and static-ness match the dex
+/// (`getBrand()Ljava/lang/String;` etc.); libjnivm binds by name and
+/// static-vs-instance, and a mismatch fails silently — the same failure that
+/// hit `NetworkUtils.getPublicIPv4Addresseses` above.
 ///
-/// The class is nine device-identity getters -- brand, model, manufacturer,
-/// device, product, build id, build release, build type, SDK version. Cordial
-/// already has truthful answers for every one of them, but they live in
-/// `native/init_params.cpp` behind `presenting_as_pc()` and the device-profile
-/// switch, both file-static. Answering them here would mean a second copy of
-/// "what device are we", and this codebase has already been bitten by exactly
-/// that: `cordial_build_user_agent` exists specifically so the web view and
-/// the engine cannot drift into two answers to that question.
-///
-/// So the follow-up is to expose the device profile from `init_params.cpp` the
-/// way `S_pub` is exposed and hook these against it -- one source of truth,
-/// nine getters. Not done here because that file is held by other work in
-/// flight, and because nothing has been observed calling any of these: the
-/// engine resolves the class and stops. A duplicated device identity shipped
-/// today to satisfy calls that never come is a worse trade than a registered
-/// class and a named follow-up.
+/// Answers come from `device_profile()` in `init_params.cpp` (declared just
+/// outside this anonymous namespace), so `CORDIAL_DEVICE_PROFILE=pc-windows-11`
+/// changes BuildInfo in the same run as InitParams and the User-Agent. Nothing
+/// has been observed calling these yet (the engine resolves the class and
+/// stops); they are hooked so a future call cannot invent a second device
+/// identity.
 class WebRtcBuildInfo : public Object {
 public:
+#define BUILDINFO_GETTER(name, field)                                          \
+    static std::shared_ptr<String> name(ENV*, Class*) {                        \
+        return S(device_profile().field);                                      \
+    }
+    BUILDINFO_GETTER(getBrand, brand)
+    BUILDINFO_GETTER(getDeviceManufacturer, manufacturer)
+    BUILDINFO_GETTER(getDeviceModel, model)
+    BUILDINFO_GETTER(getDevice, device)
+    BUILDINFO_GETTER(getDeviceProduct, product)
+    BUILDINFO_GETTER(getAndroidBuildId, build_id)
+    BUILDINFO_GETTER(getBuildType, build_type)
+    BUILDINFO_GETTER(getBuildRelease, build_release)
+    BUILDINFO_GETTER(getSdkVersion, sdk_version)
+#undef BUILDINFO_GETTER
+
     static void Register(ENV* env) {
         env->GetClass<WebRtcBuildInfo>("org/webrtc/voiceengine/BuildInfo");
+        auto c = env->GetClass("org/webrtc/voiceengine/BuildInfo");
+        // Static hooks: the dex declares static methods. Instance hooks would
+        // bind nothing and look fine until a CORDIAL_JNI_TRACE run printed
+        // `Constructed Unresolved symbol` for each.
+        c->Hook(env, "getBrand", &WebRtcBuildInfo::getBrand);
+        c->Hook(env, "getDeviceManufacturer", &WebRtcBuildInfo::getDeviceManufacturer);
+        c->Hook(env, "getDeviceModel", &WebRtcBuildInfo::getDeviceModel);
+        c->Hook(env, "getDevice", &WebRtcBuildInfo::getDevice);
+        c->Hook(env, "getDeviceProduct", &WebRtcBuildInfo::getDeviceProduct);
+        c->Hook(env, "getAndroidBuildId", &WebRtcBuildInfo::getAndroidBuildId);
+        c->Hook(env, "getBuildType", &WebRtcBuildInfo::getBuildType);
+        c->Hook(env, "getBuildRelease", &WebRtcBuildInfo::getBuildRelease);
+        c->Hook(env, "getSdkVersion", &WebRtcBuildInfo::getSdkVersion);
     }
 };
 


### PR DESCRIPTION
## Summary
Expose the device profile from `init_params.cpp` and hook `org.webrtc.voiceengine.BuildInfo` getters against it so BuildInfo is not a second source of truth.

## Changes
1. **`native/init_params.cpp`** — non-static `device_profile()` accessor (same exposure pattern as `S_pub`) returning brand/manufacturer/model/device/product/build id/type/release/sdk strings derived from the existing `device_identity()` switch.
2. **`native/unanswered_classes.cpp`** — hook all nine BuildInfo static getters via `c->Hook` (static, matching the dex) reading through `device_profile()`.

## Profile control
`CORDIAL_DEVICE_PROFILE=pc-windows-11` changes BuildInfo in the same run as InitParams and the User-Agent:
- PC profile reports `model=Windows 11 PC`, `device/product=cordial_pc`, `build_release=11`
- Android tablet / roblox-app report tablet-shaped Cordial values with `build_release=13`
- `sdk_version` stays 33` for every profile (same load-bearing gate as `DeviceParams.osVersion`)

## Binding note
Hooks are **static** (`c->Hook`), not instance — libjnivm binds by name and static-vs-instance; a mismatch fails silently (`Constructed Unresolved symbol` under `CORDIAL_JNI_TRACE=ON`).

## Testing
Could not run a full client build in this environment (see CONTRIBUTING). Change is scoped to the three steps in the issue.

Fixes #17